### PR TITLE
Colosi.robust grid info

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -1054,7 +1054,7 @@ namespace Gloebit.GloebitMoneyModule
             }
             
             if (section == "GridInfo") {
-                // If we're here, this is a rebust mode grid
+                // If we're here, this is a robust mode grid
                 string gridInfoURI = config.GetString("GridInfoURI", null);
                 // TODO: Should we store the info url?
                 m_log.InfoFormat("[GLOEBITMONEYMODULE] GRID INFO URL = {0}", gridInfoURI);
@@ -1089,11 +1089,9 @@ namespace Gloebit.GloebitMoneyModule
         }
         
         private void setGridInfo(string gridName, string gridNick, string ecoUrl) {
-            m_log.InfoFormat("[GLOEBITMONEYMODULE] Grid Name is [{0}]", gridName);
+            m_log.InfoFormat("[GLOEBITMONEYMODULE] Storing Grid Info: GridName:[{0}] GridNick:[{1}] EconomyURL:[{2}]", gridName, gridNick, ecoUrl);
             m_gridname = gridName;
-            m_log.InfoFormat("[GLOEBITMONEYMODULE] Grid Nick is [{0}]", gridNick);
             m_gridnick = gridNick;
-            m_log.InfoFormat("[GLOEBITMONEYMODULE] Economy URL is [{0}]", ecoUrl);
             if (!String.IsNullOrEmpty(ecoUrl)) {
                 m_economyURL = new Uri(ecoUrl);
             } else {


### PR DESCRIPTION
Tested this by connecting a robust sim to OSGrid.  The connection worked, we pulled the Grid info and grabbed the correct Grid name, nick and helper uri.  Unfortunately, due to what I believe were firewall issues, I haven't yet been able to teleport to the region on OSGrid to buy and see this info in the txn history, but I haven't changed any of that code.
