### PR TITLE
Fix for 0.9.0-release of OpenSim LandPass as it pulled in 0.9.1-dev c…

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -596,7 +596,7 @@ namespace Gloebit.GloebitMoneyModule
                     // TODO: may need to split on spaces or hyphens and then pull last field because flavour is not friggin public
                     char[] dChars = { '-', ' ' };
                     string[] versionParts = m_opensimVersion.Split(dChars, System.StringSplitOptions.RemoveEmptyEntries);
-                    string flavour = versionParts[versionParts.Length - 1];     // TODO: do we every have to worry about this being lenght 0?
+                    string flavour = versionParts[versionParts.Length - 1];     // TODO: do we every have to worry about this being length 0?
                     if (flavour == OpenSim.VersionInfo.Flavour.Release.ToString()) {
                         // 0.9.0 release
                         m_newLandPassFlow = true;


### PR DESCRIPTION
…hanges.

OpenSim core decided to pull all 0.9.1 modifications into 0.9.0 release as opposed to just bugfixes on features in the 0.9.0 release candidate.  So, there is a release which now requires the new dll we haven't yet released.  Additionally, the logic to apply the new flow to 0.9.1 and beyond is now wrong.  So, I've adjusted this logic to use the VERSION_FLAVOUR.  Unfortunately, this is not public, so this took some string parsing and comparison.