### PR TITLE
Updated standard for economymodule setting in Economy section of config

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -305,7 +305,7 @@ namespace Gloebit.GloebitMoneyModule
                 PriceObjectScaleFactor = config.GetFloat("PriceObjectScaleFactor", 10);
                 PriceParcelRent = config.GetInt("PriceParcelRent", 1);
                 PriceGroupCreate = config.GetInt("PriceGroupCreate", -1);
-                m_sellEnabled = config.GetBoolean("SellEnabled", false);
+                m_sellEnabled = config.GetBoolean("SellEnabled", true);
             }
             
             /********** [Gloebit] ************/


### PR DESCRIPTION
Earlier this year, discovered that the DTL/NSL money module looked for economymodule in the [Economy] section of OpenSim.ini.  I verified that the standard set by the SampleMoneyModule (which we followed) was to place it in [Startup].  I asked the core team to set the standard moving forward and they selected [Economy] but said money modules should check  both locations for now.  The GMM now conforms to the new standard as defined by core.