### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This is a plugin (addon) to enable the Gloebit currency service on an OpenSim gr
     For the latest features and to ensure compatibility with your system, we recommend building the DLL yourself.
     1. Clone or Download this repository
     2. Copy the Gloebit directory into the addon-modules directory in your OpenSim repository
-    3. Run the OpenSim runprebuild script eg:`. runprebuild.sh`
-    4. Build OpenSim eb:`xbuild`
+    3. Install mono and mono-devel version 5.12 or higher
+    4. Run the OpenSim runprebuild script eg:`. runprebuild.sh`
+    5. Build OpenSim eb:`msbuild` or `nant`
+    6. Check build result should not return error or excessive amounts of warnings(3-5 normally)
 2. Configure the plugin
   * Follow the instructions [here](http://dev.gloebit.com/opensim/configuration-instructions/).
 

--- a/addon-modules/Gloebit/prebuild-gloebit.xml
+++ b/addon-modules/Gloebit/prebuild-gloebit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Project frameworkVersion="v4_0" name="Gloebit" path="addon-modules/Gloebit/GloebitMoneyModule" type="Library">
+<Project frameworkVersion="v4_6" name="Gloebit" path="addon-modules/Gloebit/GloebitMoneyModule" type="Library">
   <Configuration name="Debug">
     <Options>
       <OutputPath>../../../bin/</OutputPath>


### PR DESCRIPTION
xbuild is no longer used, mono 5.12 should be used to build OpenSim now