### PR TITLE
Colosi.complete movement to region fixes

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
+++ b/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
@@ -3,7 +3,7 @@
 
     ;# {Enabled} {[Startup]economymodule:Gloebit} {Enable Gloebit Money Module Globally?} {false, true} false
     ;; Set to true to enable GMM for all regions controlled by this OpenSim process.
-    ;; Requires that "economymodule = Gloebit" is set in opensim.ini
+    ;; Requires that "economymodule = Gloebit" is set in [Economy] or [Startup] section of opensim.ini
     ;; If set to false, can be enabled for individual regions - see GLBEnabledOnlyInRegions below
     Enabled = false
 
@@ -51,6 +51,14 @@
 
     ;; GLBOwnerEmail should be replaced with the email address (or other contact mechanism) for the person who manages this OpenSim process.
     ; GLBOwnerEmail = Manager@example.com
+
+    ;;;;; CONFIGURE NEW SESSION MESSAGING ;;;;;
+    ;; The following determine if a user receives messaging at the start of a new session
+    ;; A new session is defined as the first time a user enters a Gloebit enabled region for a Gloebit app during a viewer login
+    ;# {GLBShowNewSessionPurchaseIM} {Show purchase gloebits IM to user at session start?} {false, true} false
+    ; GLBShowNewSessionPurchaseIM = false
+    ;# {GLBShowNewSessionAuthIM} {Show auth app IM to user at session start?} {false, true} true
+    ; GLBShowNewSessionAuthIM = true
 
     ;;;;; CONFIGURE SINGLE GLOEBIT DB FOR APP OR GRID ;;;;;;
     ;; Optional - If not configured here, Gloebit will use the DataService 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -147,6 +147,8 @@ namespace Gloebit.GloebitMoneyModule
         private static string m_contactGloebit = "Gloebit at OpenSimTransactionIssue@gloebit.com";
         private string m_contactOwner = "region or grid owner";
         private bool m_disablePerSimCurrencyExtras = false;
+        private bool m_showNewSessionPurchaseIM = false;
+        private bool m_showNewSessionAuthIM = true;
         
         // Populated from grid info
         private string m_gridnick = "unknown_grid";
@@ -414,6 +416,9 @@ namespace Gloebit.GloebitMoneyModule
                 }
                 // Should we disable adding info to OpenSimExtras map
                 m_disablePerSimCurrencyExtras = config.GetBoolean("DisablePerSimCurrencyExtras", false);
+                // Should we send new session IMs informing user how to auth or purchase gloebits
+                m_showNewSessionPurchaseIM = config.GetBoolean("GLBShowNewSessionPurchaseIM", false);
+                m_showNewSessionAuthIM = config.GetBoolean("GLBShowNewSessionAuthIM", true);
                 // Are we using custom db connection info
                 m_dbProvider = config.GetString("GLBSpecificStorageProvider");
                 m_dbConnectionString = config.GetString("GLBSpecificConnectionString");
@@ -3440,14 +3445,15 @@ namespace Gloebit.GloebitMoneyModule
                 sendMessageToClient(client, msg, client.AgentId);
                 // If authed, delivery url where user can purchase gloebits
                 if (user.IsAuthed()) {
-                    //// No longer sending auth message at new session as some users felt it was spammy.
-                    //// Instead, we are letting users know that they can click on their balance at any time for this URL
-                    //// Once viewer patch is adopted so we can tie into insufficinet funds flow, we may also remove auth messaging.
-                    // Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);
-                    // SendUrlToClient(client, "How to purchase gloebits:", "Buy gloebits you can spend in this area:", url);
+                    if (m_showNewSessionPurchaseIM) {
+                        Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);
+                        SendUrlToClient(client, "How to purchase gloebits:", "Buy gloebits you can spend in this area:", url);
+                    }
                 } else {
-                    // If not Authed, request auth.
-                    m_apiW.Authorize(user, client.Name);
+                    if (m_showNewSessionAuthIM) {
+                        // If not Authed, request auth.
+                        m_apiW.Authorize(user, client.Name);
+                    }
                 }
             });
             welcomeMessageThread.Start();

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -2312,6 +2312,11 @@ namespace Gloebit.GloebitMoneyModule
                     // TODO: may now be able to remove client from UpdateBalance as we moved this call here and out of OnNewClient
                     // Don't send Buy Gloebits messaging so that we don't spam --- last arg is 0
                     UpdateBalance(client.AgentId, client, 0);
+                } else {
+                    //update viewer balance to zero in case user came from alt money module region and has old viewer
+                    //Note: New firestorm viewer will request update and will get double send here.
+                    int zeroBal = 0;
+                    client.SendMoneyBalance(UUID.Zero, true, new byte[0], zeroBal, 0, UUID.Zero, false, UUID.Zero, false, 0, String.Empty);
                 }
                 if (user.IsNewSession(client.SessionId)) {
                     // Send welcome messaging


### PR DESCRIPTION
3 fixes
- #74 added OnCompleteMovementToRegion code to a worker thread queue
--- NOTE: Chose not to do #73 for now as that requires some other architectural consideration and #74 should fully resolve the pressing issue
- #75 updates a user's balance to zero when not authorized and enters Gloebit enabled region from a region which had an alternate currency and may have had a non-zero balance
- #72 Allow owner to turn off New Session IMs