### PR TITLE
Cleaned most warnings

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
@@ -654,7 +654,6 @@ namespace Gloebit.GloebitMoneyModule {
                             // nothing to tell user.  buyer doesn't need to know it was double submitted
                             m_log.ErrorFormat ("[GLOEBITMONEYMODULE].transactU2UCompleted race condition.  You double submitted transaction:{0}", tID);
                             return; /* don't report anything as the other flow this hit will handle reporting */
-                            break;
                         default:
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted unhandled queueing failure:{0}  transactionID:{1}", failure, tID);
                             additionalDetailStr = reason;

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -492,7 +492,7 @@ namespace Gloebit.GloebitMoneyModule
                         // TODO: do we want anything else from grid info?
                     }
                 } catch (Exception e) {
-                    m_log.ErrorFormat("[GloebitMoneyModule] Failed to retrieve Grid Info.");
+                    m_log.ErrorFormat("[GloebitMoneyModule] Failed to retrieve Grid Info. {0}", e);
                 }
             }
         }
@@ -720,7 +720,7 @@ namespace Gloebit.GloebitMoneyModule
             
             // Grab info all vars we'll def need
             TransactionType txnType = TransactionType.MOVE_MONEY_GENERAL;
-            string txnTypeString = "MoveMoneyGeneral";
+            string txnTypeString;
             //Scene s = LocateSceneClientIn(agentID);
             //string regionID = s.RegionInfo.RegionID.ToString();
             Scene s = null;
@@ -782,7 +782,7 @@ namespace Gloebit.GloebitMoneyModule
                     m_log.DebugFormat("[GLOEBITMONEYMODULE] found {0} matching parcels", found);
                     
                     // Create the descMap extra details using the parcel we've found if we've found exactly one match.
-                    int parcelLocalID = 0;
+                    //int parcelLocalID = 0;
                     if (found == 1) {
                         descMap = buildOpenSimTransactionDescMap(regionName, regionID.ToString(), "ParcelBuyPass", parcel.LandData);
                         partID = parcel.LandData.GlobalID;
@@ -2498,11 +2498,9 @@ namespace Gloebit.GloebitMoneyModule
                     description = e.description;
                     */
                 return;
-                break;
             default:
                 m_log.ErrorFormat("UNKNOWN Unimplemented transactiontype received in OnMoneyTransfer: {0}", e.transactiontype);
                 return;
-                break;
             }
 
             /******** Set up necessary parts for gloebit transact-u2u **********/

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -720,7 +720,7 @@ namespace Gloebit.GloebitMoneyModule
             
             // Grab info all vars we'll def need
             TransactionType txnType = TransactionType.MOVE_MONEY_GENERAL;
-            string txnTypeString;
+            //string txnTypeString;
             //Scene s = LocateSceneClientIn(agentID);
             //string regionID = s.RegionInfo.RegionID.ToString();
             Scene s = null;
@@ -739,7 +739,7 @@ namespace Gloebit.GloebitMoneyModule
                 case MoneyTransactionType.LandPassSale:
                     // User buys time-limited pass to access parcel
                     // Comes through ParcelBuyPass event pre 0.9.1; MoveMoney 0.9.1 on.
-                    txnTypeString = "ParcelBuyPass";
+                    //txnTypeString = "ParcelBuyPass";
                     txnType = TransactionType.USER_BUYS_LANDPASS;
                     
                     // Try to retrieve the info we want by parsing the text string
@@ -806,7 +806,7 @@ namespace Gloebit.GloebitMoneyModule
                 default:
                     // Other - not in core at time of writing.
                     //description = String.Format("Fee (type {0}) on {1}, {2}", type, regionname, m_gridnick);
-                    txnTypeString = "MoveMoneyGeneral";
+                    //txnTypeString = "MoveMoneyGeneral";
                     txnType = TransactionType.MOVE_MONEY_GENERAL;
                     m_log.ErrorFormat("[GLOEBITMONEYMODULE] MoveMoney for MoneyTransactionType [{0}] with description [{1}] not implemented.  Please contact Gloebit and ask them to implement.", type, text);
                     alertUsersTransactionPreparationFailure(TransactionType.MOVE_MONEY_GENERAL, TransactionPrecheckFailure.SALE_TYPE_INVALID, LocateClientObject(fromUser));

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
@@ -202,7 +202,6 @@ namespace Gloebit.GloebitMoneyModule {
                     return null;
                 default:
                     throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one subscription for {0} {1} {2}", objectIDStr, appKey, apiUrl));
-                    return null;
                 }
             }
             m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND SUBSCRIPTION in cache! oID:{0} appKey:{1} url:{2} sID:{3} oN:{4} oD:{5}", subscription.ObjectID, subscription.AppKey, subscription.GlbApiUrl, subscription.SubscriptionID, subscription.ObjectName, subscription.Description);
@@ -249,10 +248,9 @@ namespace Gloebit.GloebitMoneyModule {
                 return null;
             default:
                 throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one subscription for {0} {1}", subscriptionIDStr, apiUrl));
-                return null;
             }
-            m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND SUBSCRIPTION in cache! oID:{0} appKey:{1} url:{2} sID:{3} oN:{4} oD:{5}", subscription.ObjectID, subscription.AppKey, subscription.GlbApiUrl, subscription.SubscriptionID, subscription.ObjectName, subscription.Description);
-            return subscription;
+            //m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND SUBSCRIPTION in cache! oID:{0} appKey:{1} url:{2} sID:{3} oN:{4} oD:{5}", subscription.ObjectID, subscription.AppKey, subscription.GlbApiUrl, subscription.SubscriptionID, subscription.ObjectName, subscription.Description);
+            //return subscription;
         }
 
         public override bool Equals(Object obj)

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
@@ -221,7 +221,6 @@ namespace Gloebit.GloebitMoneyModule {
                     return null;
                 default:
                     throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one transaction for {0}", transactionIDStr));
-                    return null;
                 }
             }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -164,7 +164,7 @@ namespace Gloebit.GloebitMoneyModule
                     // call parent
                     return base.Store(txn);
 		} catch(System.OverflowException e) {
-                    m_log.ErrorFormat("GloebitTransactionData.PGSQLImpl: Failure storing transaction type:{0}, SaleType:{1}, PayerEndingBalance:{2}, cTime:{3}, enactedTime:{4}, finishedTime:{5}", txn.TransactionType, txn.SaleType, txn.PayerEndingBalance, txn.cTime, txn.enactedTime, txn.finishedTime);
+                    m_log.ErrorFormat("GloebitTransactionData.PGSQLImpl: Failure storing transaction type:{0}, SaleType:{1}, PayerEndingBalance:{2}, cTime:{3}, enactedTime:{4}, finishedTime:{5}, stacktrace:{6}", txn.TransactionType, txn.SaleType, txn.PayerEndingBalance, txn.cTime, txn.enactedTime, txn.finishedTime, e);
 		    throw;
 		}
             }


### PR DESCRIPTION
Cleaned most warnings related to unreachable and unused code. Remaining warnings are related to prebuild and dependencies and need review still. Changes are verified to compile, but not verified for functionality. Please maintain an as-stale-as-possible approach regarding compiler warnings so actual problems can be identified easily, ideally compiler should not emit any warnings for modules.