### PR TITLE
Make popups configurable, attempt to handle db connection loss, fix spelling, new http workflows

### DIFF
--- a/addon-modules/Gloebit/GloebitMoneyModule/GMMDialog.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GMMDialog.cs
@@ -128,7 +128,7 @@ namespace Gloebit.GloebitMoneyModule {
                     myChannel = c_MaxChannel;
                 }
             } while (local_lc != Interlocked.CompareExchange(ref s_lastChannel, myChannel, local_lc));
-            // while ensures that one and only one thread finieshes and modifies s_lastChannel
+            // while ensures that one and only one thread finishes and modifies s_lastChannel
             // If s_lastChannel has changed since local_lc was set, this fails and the loop runs again.
             // If multiple threads are executing at the same time, at least one will always succeed.
 
@@ -188,7 +188,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// --- If not, consider purging old Dialogs.
         /// --- If it is on a channel for a Dialog for this user, validate that it's not an imposter.
         /// --- Call ProcessResponse on derived Dialog class
-        /// Callback registerd in Dialog.Open()
+        /// Callback registered in Dialog.Open()
         /// EVENT:
         ///     ChatFromClientEvent is triggered via ChatModule (or
         ///     substitutes thereof) when a chat message
@@ -405,7 +405,7 @@ namespace Gloebit.GloebitMoneyModule {
         public readonly string ObjectDescription;
 
         // Details of attempted, failed transaction resulting in this create subscription authorization dialog
-        public readonly UUID TransactionID;  // id of the auto debit transaciton which failed due to lack of authorization
+        public readonly UUID TransactionID;  // id of the auto debit transaction which failed due to lack of authorization
         public readonly UUID PayeeID;        // ID of the agent receiving the proceeds
         public readonly string PayeeName;    // name of the agent receiving the proceeds
         public readonly int Amount;          // The amount of the auto-debit transaction
@@ -458,7 +458,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="payeeID">UUID of the OpenSim user who is being paid by the object/script/subscription</param>
         /// <param name="payeeName">String name of the OpenSim user who is being paid by the object/script/subscription</param>
         /// <param name="amount">int amount of the failed transaction which triggered this authorization request</param>
-        /// <param name="subscriptionID">UUID of subscription created/returnd by Gloebit and for which authorization is being requested</param>
+        /// <param name="subscriptionID">UUID of subscription created/returned by Gloebit and for which authorization is being requested</param>
         /// <param name="activeApiW">GloebitAPIWrapper active for this GMM</param>
         /// <param name="appCallbackBaseURI">Base URI for any callbacks this request makes back into the app</param>
         public CreateSubscriptionAuthorizationDialog(IClientAPI client, UUID agentID, string agentName, UUID objectID, string objectName, string objectDescription, UUID transactionID, UUID payeeID, string payeeName, int amount, UUID subscriptionID, GloebitAPIWrapper activeApiW, Uri appCallbackBaseURI) : base(client, agentID)
@@ -549,7 +549,7 @@ namespace Gloebit.GloebitMoneyModule {
         public readonly string ObjectDescription;
 
         // Details of attempted, failed transaction resulting in this create subscription authorization dialog
-        public readonly UUID TransactionID;  // id of the auto debit transaciton which failed due to lack of authorization
+        public readonly UUID TransactionID;  // id of the auto debit transaction which failed due to lack of authorization
         public readonly UUID PayeeID;        // ID of the agent receiving the proceeds
         public readonly string PayeeName;    // name of the agent receiving the proceeds
         public readonly int Amount;          // The amount of the auto-debit transaction
@@ -608,7 +608,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="payeeID">UUID of the OpenSim user who is being paid by the object/script/subscription</param>
         /// <param name="payeeName">String name of the OpenSim user who is being paid by the object/script/subscription</param>
         /// <param name="amount">int amount of the failed transaction which triggered this authorization request</param>
-        /// <param name="subscriptionID">UUID of subscription created/returnd by Gloebit and for which authorization is being requested</param>
+        /// <param name="subscriptionID">UUID of subscription created/returned by Gloebit and for which authorization is being requested</param>
         /// <param name="subscriptionAuthorizationID">UUID of the pending subscription authorization returned by Gloebit with the failed transaction</param>
         /// <param name="activeApiW">GloebitAPIWrapper active for this GMM</param>
         /// <param name="appCallbackBaseURI">Base URI for any callbacks this request makes back into the app</param>

--- a/addon-modules/Gloebit/GloebitMoneyModule/GMMLoginBalanceRequest.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GMMLoginBalanceRequest.cs
@@ -40,7 +40,7 @@ namespace Gloebit.GloebitMoneyModule {
     /// <summary>
     /// Class which is a hack to deal with the fact that a balance request is made
     /// twice when a user logs into a GMM enabled region (once for connect to region and once by viewer after login).
-    /// This causes the balance to be reqeusted twice, and if not authed, the user to be asked to auth twice.
+    /// This causes the balance to be requested twice, and if not authed, the user to be asked to auth twice.
     /// This class is designed solely for preventing the second request in that single case.
     /// </summary>
     public class LoginBalanceRequest

--- a/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
+++ b/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
@@ -59,6 +59,8 @@
     ; GLBShowNewSessionPurchaseIM = false
     ;# {GLBShowNewSessionAuthIM} {Show auth app IM to user at session start?} {false, true} true
     ; GLBShowNewSessionAuthIM = true
+	;# {GLBShowWelcomeMessage} {Show welcome message when entering a region}
+	; GLBShowWelcomeMessage = true
 
     ;;;;; CONFIGURE SINGLE GLOEBIT DB FOR APP OR GRID ;;;;;;
     ;; Optional - If not configured here, Gloebit will use the DataService 

--- a/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
+++ b/addon-modules/Gloebit/GloebitMoneyModule/Gloebit.ini.example
@@ -59,8 +59,8 @@
     ; GLBShowNewSessionPurchaseIM = false
     ;# {GLBShowNewSessionAuthIM} {Show auth app IM to user at session start?} {false, true} true
     ; GLBShowNewSessionAuthIM = true
-	;# {GLBShowWelcomeMessage} {Show welcome message when entering a region}
-	; GLBShowWelcomeMessage = true
+    ;# {GLBShowWelcomeMessage} {Show welcome message when entering a region}
+    ; GLBShowWelcomeMessage = true
 
     ;;;;; CONFIGURE SINGLE GLOEBIT DB FOR APP OR GRID ;;;;;;
     ;; Optional - If not configured here, Gloebit will use the DataService 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
@@ -298,7 +298,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="payerUser">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="payerUser">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <returns>true if async transact web request was built and submitted successfully; false if failed to submit request;  If true, IAsyncEndpointCallback transactCompleted should eventually be called with additional details on state of request.</returns>
         public bool Transact(GloebitTransaction txn, string description, OSDMap descMap, GloebitUser payerUser, Uri baseURI) {
@@ -355,7 +355,7 @@ namespace Gloebit.GloebitMoneyModule {
 
         
 
-        // TODO: does recipient have to authorize app?  Do they need to become a merchant on that platform or opt in to agreeing to receive Gloebits?  How do they currently authorize sale on a grid?
+        // TODO: does recipient have to authorize app?  Do they need to become a merchant on that platform or opt in to agreeing to receive gloebits?  How do they currently authorize sale on a grid?
         // TODO: Should we pass a bool for charging a fee or the actual fee % -- to the module owner --- could always charge a fee.  could be % set in app for when charged.  could be % set for each transaction type in app.
         // TODO: Should we always charge our fee, or have a bool or transaction type for occasions when we may not charge?
         // TODO: Do we need an endpoint for reversals/refunds, or just an admin interface from Gloebit?
@@ -371,9 +371,9 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="sender">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipient">GloebitUser object for the user receiving the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipientEmail">Email address of the user on this grid receiving the Gloebits.  Empty string if user created account without email.</param>
+        /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <returns>true if async transactU2U web request was built and submitted successfully; false if failed to submit request;  If true, IAsyncEndpointCallback transactU2UCompleted should eventually be called with additional details on state of request.</returns>
         public bool TransactU2U(GloebitTransaction txn, string description, OSDMap descMap, GloebitUser sender, GloebitUser recipient, string recipientEmail, Uri baseURI) {
@@ -449,9 +449,9 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="sender">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipient">GloebitUser object for the user receiving the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipientEmail">Email address of the user on this grid receiving the Gloebits.  Empty string if user created account without email.</param>
+        /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <param name="stage">TransactionStage handed back to caller representing stage of transaction that failed or completed.</param>
         /// <param name="failure">TransactionFailure handed back to caller representing specific transaction failure, or NONE.</param>
@@ -471,7 +471,7 @@ namespace Gloebit.GloebitMoneyModule {
             // If the recipient has ever authorized, we have an AppUserID from Gloebit which will allow identification.
             // If not, Gloebit will attempt id from email.
             // TODO: If we use emails, we may need to make sure account merging works for email/3rd party providers.
-            // TODO: If we allow anyone to receive, need to ensure that Gloebits received are locked down until user authenticates as merchant.
+            // TODO: If we allow anyone to receive, need to ensure that gloebits received are locked down until user authenticates as merchant.
             
             // ************ BUILD AND SEND TRANSACT U2U POST REQUEST ******** //
             
@@ -616,7 +616,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="transact_params">OSDMap which will be populated with form parameters.</param>
         /// <param name="txn">GloebitTransaction representing local transaction we are create transact_params from.</param>
         /// <param name="recipientGloebitID">UUID from the Gloebit system of user being paid.  May be empty.</param>
-        /// <param name="recipientEmail">Email of the user being paid Gloebits.  May be empty.</param>
+        /// <param name="recipientEmail">Email of the user being paid gloebits.  May be empty.</param>
         private void PopulateTransactParamsU2U(OSDMap transact_params, GloebitTransaction txn, string recipientGloebitID, string recipientEmail)
         {
             /***** U2U specific transact params *****/
@@ -694,7 +694,7 @@ namespace Gloebit.GloebitMoneyModule {
             // TODO: Adding an "early-enact-failed" status to make this simpler
             } else if (status == "queued") {                                /* successfully queued.  an early enact failed */
                 // This is a complex error/flow response which we should really consider if there is a better way to handle.
-                // Is this always a permanent failure?  Could this succeed in queue if user purchased Gloebits at same time?
+                // Is this always a permanent failure?  Could this succeed in queue if user purchased gloebits at same time?
                 // Can anything other than insufficient funds cause this problem?  Internet Issue?
                 stage = TransactionStage.ENACT_GLOEBIT;
                 // TODO: perhaps the stage should be queue here, and early_enact error as this is not being enacted by a transaction processor.
@@ -719,10 +719,10 @@ namespace Gloebit.GloebitMoneyModule {
                     // nothing to tell user.  buyer doesn't need to know it was double submitted
                     stage = TransactionStage.QUEUE;
                     failure = TransactionFailure.RACE_CONDITION;
-                } else if (status == "cannot-spend") {                      /* Buyer's Gloebit account is locked and not allowed to spend Gloebits */
+                } else if (status == "cannot-spend") {                      /* Buyer's Gloebit account is locked and not allowed to spend gloebits */
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYER_ACCOUNT_LOCKED;
-                } else if (status == "cannot-receive") {                    /* Seller's Gloebit account can not receive Gloebits */
+                } else if (status == "cannot-receive") {                    /* Seller's Gloebit account can not receive gloebits */
                     // TODO: Check role in new system.  This is for role=Payee, not role=Application
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYEE_CANNOT_RECEIVE;
@@ -1060,7 +1060,7 @@ namespace Gloebit.GloebitMoneyModule {
                             paramString = OSDParser.SerializeJsonString(paramMap);
                         } else {
                             // ERROR - we are not handling this content type properly
-                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognised content type:{1}", relativeURL, contentType);
+                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognized content type:{1}", relativeURL, contentType);
                             return null;
                         }
                 
@@ -1078,7 +1078,7 @@ namespace Gloebit.GloebitMoneyModule {
                     break;
                 default:
                     // ERROR - we are not handling this request type properly
-                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognised web request method:{1}", relativeURL, method);
+                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognized web request method:{1}", relativeURL, method);
                     return null;
             }
             return request;
@@ -1219,8 +1219,8 @@ namespace Gloebit.GloebitMoneyModule {
             ENACT_ASSET     = 650,   // performing local components of transaction
             CONSUME_GLOEBIT = 700,   // committing Gloebit components of transaction
             CONSUME_ASSET   = 750,   // committing local components of transaction
-            CANCEL_GLOEBIT  = 800,   // cancelling Gloebit components of transaction
-            CANCEL_ASSET    = 850,   // cancelling local components of transaction
+            CANCEL_GLOEBIT  = 800,   // canceling Gloebit components of transaction
+            CANCEL_ASSET    = 850,   // canceling local components of transaction
             COMPLETE        = 1000,  // Not really a stage.  May not need this.  Once local asset is consumed, we are complete.
         }
         

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
@@ -298,7 +298,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="payerUser">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="payerUser">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <returns>true if async transact web request was built and submitted successfully; false if failed to submit request;  If true, IAsyncEndpointCallback transactCompleted should eventually be called with additional details on state of request.</returns>
         public bool Transact(GloebitTransaction txn, string description, OSDMap descMap, GloebitUser payerUser, Uri baseURI) {
@@ -355,7 +355,7 @@ namespace Gloebit.GloebitMoneyModule {
 
         
 
-        // TODO: does recipient have to authorize app?  Do they need to become a merchant on that platform or opt in to agreeing to receive gloebits?  How do they currently authorize sale on a grid?
+        // TODO: does recipient have to authorize app?  Do they need to become a merchant on that platform or opt in to agreeing to receive Gloebits?  How do they currently authorize sale on a grid?
         // TODO: Should we pass a bool for charging a fee or the actual fee % -- to the module owner --- could always charge a fee.  could be % set in app for when charged.  could be % set for each transaction type in app.
         // TODO: Should we always charge our fee, or have a bool or transaction type for occasions when we may not charge?
         // TODO: Do we need an endpoint for reversals/refunds, or just an admin interface from Gloebit?
@@ -371,9 +371,9 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
+        /// <param name="sender">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipient">GloebitUser object for the user receiving the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipientEmail">Email address of the user on this grid receiving the Gloebits.  Empty string if user created account without email.</param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <returns>true if async transactU2U web request was built and submitted successfully; false if failed to submit request;  If true, IAsyncEndpointCallback transactU2UCompleted should eventually be called with additional details on state of request.</returns>
         public bool TransactU2U(GloebitTransaction txn, string description, OSDMap descMap, GloebitUser sender, GloebitUser recipient, string recipientEmail, Uri baseURI) {
@@ -449,9 +449,9 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
-        /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
-        /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
+        /// <param name="sender">GloebitUser object for the user sending the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipient">GloebitUser object for the user receiving the Gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
+        /// <param name="recipientEmail">Email address of the user on this grid receiving the Gloebits.  Empty string if user created account without email.</param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <param name="stage">TransactionStage handed back to caller representing stage of transaction that failed or completed.</param>
         /// <param name="failure">TransactionFailure handed back to caller representing specific transaction failure, or NONE.</param>
@@ -471,7 +471,7 @@ namespace Gloebit.GloebitMoneyModule {
             // If the recipient has ever authorized, we have an AppUserID from Gloebit which will allow identification.
             // If not, Gloebit will attempt id from email.
             // TODO: If we use emails, we may need to make sure account merging works for email/3rd party providers.
-            // TODO: If we allow anyone to receive, need to ensure that gloebits received are locked down until user authenticates as merchant.
+            // TODO: If we allow anyone to receive, need to ensure that Gloebits received are locked down until user authenticates as merchant.
             
             // ************ BUILD AND SEND TRANSACT U2U POST REQUEST ******** //
             
@@ -616,7 +616,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="transact_params">OSDMap which will be populated with form parameters.</param>
         /// <param name="txn">GloebitTransaction representing local transaction we are create transact_params from.</param>
         /// <param name="recipientGloebitID">UUID from the Gloebit system of user being paid.  May be empty.</param>
-        /// <param name="recipientEmail">Email of the user being paid gloebits.  May be empty.</param>
+        /// <param name="recipientEmail">Email of the user being paid Gloebits.  May be empty.</param>
         private void PopulateTransactParamsU2U(OSDMap transact_params, GloebitTransaction txn, string recipientGloebitID, string recipientEmail)
         {
             /***** U2U specific transact params *****/
@@ -694,7 +694,7 @@ namespace Gloebit.GloebitMoneyModule {
             // TODO: Adding an "early-enact-failed" status to make this simpler
             } else if (status == "queued") {                                /* successfully queued.  an early enact failed */
                 // This is a complex error/flow response which we should really consider if there is a better way to handle.
-                // Is this always a permanent failure?  Could this succeed in queue if user purchased gloebits at same time?
+                // Is this always a permanent failure?  Could this succeed in queue if user purchased Gloebits at same time?
                 // Can anything other than insufficient funds cause this problem?  Internet Issue?
                 stage = TransactionStage.ENACT_GLOEBIT;
                 // TODO: perhaps the stage should be queue here, and early_enact error as this is not being enacted by a transaction processor.
@@ -719,10 +719,10 @@ namespace Gloebit.GloebitMoneyModule {
                     // nothing to tell user.  buyer doesn't need to know it was double submitted
                     stage = TransactionStage.QUEUE;
                     failure = TransactionFailure.RACE_CONDITION;
-                } else if (status == "cannot-spend") {                      /* Buyer's gloebit account is locked and not allowed to spend gloebits */
+                } else if (status == "cannot-spend") {                      /* Buyer's Gloebit account is locked and not allowed to spend Gloebits */
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYER_ACCOUNT_LOCKED;
-                } else if (status == "cannot-receive") {                    /* Seller's gloebit account can not receive gloebits */
+                } else if (status == "cannot-receive") {                    /* Seller's Gloebit account can not receive Gloebits */
                     // TODO: Check role in new system.  This is for role=Payee, not role=Application
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYEE_CANNOT_RECEIVE;
@@ -1219,7 +1219,7 @@ namespace Gloebit.GloebitMoneyModule {
             ENACT_ASSET     = 650,   // performing local components of transaction
             CONSUME_GLOEBIT = 700,   // committing Gloebit components of transaction
             CONSUME_ASSET   = 750,   // committing local components of transaction
-            CANCEL_GLOEBIT  = 800,   // cancelling gloebit components of transaction
+            CANCEL_GLOEBIT  = 800,   // cancelling Gloebit components of transaction
             CANCEL_ASSET    = 850,   // cancelling local components of transaction
             COMPLETE        = 1000,  // Not really a stage.  May not need this.  Once local asset is consumed, we are complete.
         }

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPI.cs
@@ -88,7 +88,7 @@ namespace Gloebit.GloebitMoneyModule {
                 responseStream = null;
                 
                 bufferRead = new byte[BUFFER_SIZE];
-                streamDecoder = Encoding.UTF8.GetDecoder();     // Create Decoder for appropriate enconding type.
+                streamDecoder = Encoding.UTF8.GetDecoder();     // Create Decoder for appropriate encoding type.
                 responseData = new StringBuilder(String.Empty);
 
                 this.continuation = continuation;
@@ -232,7 +232,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Returns zero if a link between this OpenSim user and a Gloebit account have not been created and the user has not granted authorization to this grid/region.
         /// Requires "balance" in scope of authorization token.
         /// </summary>
-        /// <returns>The Gloebit balance for the Gloebit accunt the user has linked to this OpenSim agentID on this grid/region.  Returns zero if a link between this OpenSim user and a Gloebit account has not been created and the user has not granted authorization to this grid/region.</returns>
+        /// <returns>The Gloebit balance for the Gloebit account the user has linked to this OpenSim agentID on this grid/region.  Returns zero if a link between this OpenSim user and a Gloebit account has not been created and the user has not granted authorization to this grid/region.</returns>
         /// <param name="user">GloebitUser object for the OpenSim user for whom the balance request is being made. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="invalidatedToken">Bool set to true if request fails due to a bad token which we have invalidated.  Eventually, this should be a more general error interface</param>
         /// <returns>Double balance of user or 0.0 if fails for any reason</returns>
@@ -297,7 +297,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </remarks>
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <param name="payerUser">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         /// <returns>true if async transact web request was built and submitted successfully; false if failed to submit request;  If true, IAsyncEndpointCallback transactCompleted should eventually be called with additional details on state of request.</returns>
@@ -370,7 +370,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </remarks>
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
@@ -382,7 +382,7 @@ namespace Gloebit.GloebitMoneyModule {
             
             // ************ IDENTIFY GLOEBIT RECIPIENT ******** //
             // 1. If the recipient has authed ever, we'll have a recipient.GloebitID to use.
-            // 2. If not, and the recipeint's account is on this grid, Get the email from the profile for the account.
+            // 2. If not, and the recipient's account is on this grid, Get the email from the profile for the account.
             
             // ************ BUILD AND SEND TRANSACT U2U POST REQUEST ******** //
             
@@ -448,7 +448,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </remarks>
         /// <param name="txn">GloebitTransaction representing local transaction we are requesting.  This is prebuilt by GMM, and already includes most transaciton details such as amount, payer/payee id and name.  <see cref="GloebitTransaction"/></param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <param name="sender">GloebitUser object for the user sending the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="recipient">GloebitUser object for the user receiving the gloebits. <see cref="GloebitUser.Get(UUID)"/></param>
         /// <param name="recipientEmail">Email address of the user on this grid receiving the gloebits.  Empty string if user created account without email.</param>
@@ -458,7 +458,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <returns>
         /// true if sync transactU2U web request was built and submitted successfully and returned a successful response from the web service.
         /// --- successful response means that all Gloebit components of the transaction enacted successfully, and transaction would only fail if local
-        ///     component enaction failed.  (Note: possibiliy of only "queue" success if resubmitted)
+        ///     component enaction failed.  (Note: possibility of only "queue" success if resubmitted)
         /// false if failed to submit request, or if response returned false.
         /// --- See out parameters stage and failure for details on failure.
         /// If true, or if false in any stage after SUBMIT, IAsyncEndpointCallback transactU2UCompleted will be called with additional details on state of request prior to this function returning.
@@ -554,7 +554,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// <param name="txn">GloebitTransaction representing local transaction we are create transact_params from.</param>
         /// <param name="description">Description of purpose of transaction recorded in Gloebit transaction histories.  Should eventually be added to txn and removed as parameter</param>
         /// <param name="senderGloebitID">UUID from the Gloebit system of user making payment.</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <param name="baseURI">The base url where this server's http services can be accessed.  Used by enact/consume/cancel callbacks for local transaction part requiring processing.</param>
         private void PopulateTransactParamsBase(OSDMap transact_params, GloebitTransaction txn, string description, string senderGloebitID, OSDMap descMap, Uri baseURI)
         {
@@ -631,7 +631,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
         
         /// <summary>
-        /// Given the response from a TransactU2U web reqeust, retrieves and stores vital information in the transaction object and data store.
+        /// Given the response from a TransactU2U web request, retrieves and stores vital information in the transaction object and data store.
         /// </summary>
         /// <param name="txn">GloebitTransaction representing local transaction for which we received the response.</param>
         /// <param name="responseDataMap">OSDMap containing the web response body.</param>
@@ -708,7 +708,7 @@ namespace Gloebit.GloebitMoneyModule {
                     // Shouldn't ever get here.
                     failure = TransactionFailure.ENACTING_GLOEBIT_FAILED;
                 }
-            } else {                                                        /* failure prior to successful queing.  Something requires fixing */
+            } else {                                                        /* failure prior to successful queuing.  Something requires fixing */
                 if (reason == "unknown OAuth2 token") {                     /* Invalid Token.  May have been revoked by user or expired */
                     stage = TransactionStage.AUTHENTICATE;
                     failure = TransactionFailure.AUTHENTICATION_FAILED;
@@ -729,7 +729,7 @@ namespace Gloebit.GloebitMoneyModule {
                 } else if (status == "unknown-merchant") {                  /* can not identify merchant from params supplied by app */
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYEE_CANNOT_BE_IDENTIFIED;
-                } else if (reason == "transaction is missing parameters needed to identify gloebit account of seller - supply at least one of seller-email-address or seller-id-from-gloebit.") {
+                } else if (reason == "transaction is missing parameters needed to identify Gloebit account of seller - supply at least one of seller-email-address or seller-id-from-gloebit.") {
                     // TODO: handle this better in the long run
                     stage = TransactionStage.VALIDATE;
                     failure = TransactionFailure.PAYEE_CANNOT_BE_IDENTIFIED;
@@ -794,7 +794,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Request a new subscription be created by Gloebit for this app.
         /// Subscriptions are required for any recurring, unattended/automated payments that a user will sign up for.
         /// Upon completion of this request, the interface function CreateSubscriptionCompleted will be called with the results.
-        /// If successful, an ID will be created and returnd by Gloebit which should be used for requesting user authorization and
+        /// If successful, an ID will be created and returned by Gloebit which should be used for requesting user authorization and
         /// creating transactions under this subscription code.
         /// </summary>
         /// <param name="subscription">Local GloebitSubscription with the details for this subscription.</param>
@@ -888,7 +888,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Request creation of a pending authorization for an existing subscription for this application.
         /// A subscription authorization must be created and then approved by the user before a recurring, unattended/automated payment
         /// can be requested for this user by this app.  The authorization is for a single, specific subscription.
-        /// The authorization is not only specific to the Gloebit account linked to this user, but also to the app account by the id of the use ron this app.
+        /// The authorization is not only specific to the Gloebit account linked to this user, but also to the app account by the id of the use on this app.
         /// A subscription for this app must already have been created via CreateSubscription.
         /// Upon completion of this request, the interface function CreateSubscriptionAuthorizationCompleted will be called with the results.
         /// The application does not need to store SubscriptionAuthorizations locally.  A transaction can be submitted without knowledge of an
@@ -956,7 +956,7 @@ namespace Gloebit.GloebitMoneyModule {
                     } else if (status == "duplicate-and-already-approved-by-user") {
                         m_log.DebugFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization duplicate request to create subscription - subscription has already been approved by user.");
                     } else if (status == "duplicate-and-previously-declined-by-user") {
-                        m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization SUCCESS & FAILURE - user previously declined authorization -- consider if app should re-request or if that is harrassing user or has Gloebit API reset this automatcially?. status:{0} reason:{1}", status, reason);
+                        m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization SUCCESS & FAILURE - user previously declined authorization -- consider if app should re-request or if that is harassing user or has Gloebit API reset this automatically?. status:{0} reason:{1}", status, reason);
                     }
                     
                     string sPending = responseDataMap["pending"];
@@ -976,7 +976,7 @@ namespace Gloebit.GloebitMoneyModule {
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization FAILED - app has disabled this subscription. status:{0} reason:{1}", status, reason);
                             break;
                         case "duplicate-and-previously-declined-by-user":
-                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization FAILED - user previously declined authorization -- consider if app should re-request or if that is harrassing user. status:{0} reason:{1}", status, reason);
+                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.CreateSubscriptionAuthorization FAILED - user previously declined authorization -- consider if app should re-request or if that is harassing user. status:{0} reason:{1}", status, reason);
                             break;
                         default:
                             switch(reason) {
@@ -1060,7 +1060,7 @@ namespace Gloebit.GloebitMoneyModule {
                             paramString = OSDParser.SerializeJsonString(paramMap);
                         } else {
                             // ERROR - we are not handling this content type properly
-                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognized content type:{1}", relativeURL, contentType);
+                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognised content type:{1}", relativeURL, contentType);
                             return null;
                         }
                 
@@ -1078,7 +1078,7 @@ namespace Gloebit.GloebitMoneyModule {
                     break;
                 default:
                     // ERROR - we are not handling this request type properly
-                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognized web request method:{1}", relativeURL, method);
+                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] GloebitAPI.BuildGloebitRequest relativeURL:{0}, unrecognised web request method:{1}", relativeURL, method);
                     return null;
             }
             return request;
@@ -1211,16 +1211,16 @@ namespace Gloebit.GloebitMoneyModule {
         {
             BEGIN           = 0,    // Not really a stage.  may not need this
             BUILD           = 100,   // Preparing the transaction locally for submission
-            SUBMIT          = 200,   // Submitting the transaciton to Gloebit via the API Endpoints.
+            SUBMIT          = 200,   // Submitting the transaction to Gloebit via the API Endpoints.
             AUTHENTICATE    = 300,   // Checking OAuth Token included in header
-            VALIDATE        = 400,   // Validating the txn form submitted to Gloebit -- may need to add in somesubscription specific validations
-            QUEUE           = 500,   // Queing the transaction for processing
-            ENACT_GLOEBIT   = 600,   // perfoming Gloebit components of transaction
+            VALIDATE        = 400,   // Validating the txn form submitted to Gloebit -- may need to add in some subscription specific validations
+            QUEUE           = 500,   // Queueing the transaction for processing
+            ENACT_GLOEBIT   = 600,   // performing Gloebit components of transaction
             ENACT_ASSET     = 650,   // performing local components of transaction
             CONSUME_GLOEBIT = 700,   // committing Gloebit components of transaction
             CONSUME_ASSET   = 750,   // committing local components of transaction
-            CANCEL_GLOEBIT  = 800,   // canceling gloebit components of transaction
-            CANCEL_ASSET    = 850,   // canceling local components of transaction
+            CANCEL_GLOEBIT  = 800,   // cancelling gloebit components of transaction
+            CANCEL_ASSET    = 850,   // cancelling local components of transaction
             COMPLETE        = 1000,  // Not really a stage.  May not need this.  Once local asset is consumed, we are complete.
         }
         

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
@@ -173,7 +173,7 @@ namespace Gloebit.GloebitMoneyModule {
             Uri url = BuildPurchaseURI(m_platformAccessors.GetBaseURI(), u);
             Hashtable response = new Hashtable();
             response["int_response_code"] = 200;
-            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend Gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need Gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
+            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
             response["content_type"] = "text/html";
 
             return response;
@@ -209,7 +209,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Retrieves the Gloebit balance of the Gloebit account linked to the user defined by the userIDOnApp.
+        /// Retrieves the gloebit balance of the Gloebit account linked to the user defined by the userIDOnApp.
         /// If there is no token, or an invalid token on file, and forceAuthOnInvalidToken is true, we request authorization from the AppUser.
         /// If we request authorization, the userName is provided to that API Authorize function.  Otherwise, it is not used.
         /// </summary>
@@ -268,13 +268,13 @@ namespace Gloebit.GloebitMoneyModule {
         //       if it can supply extra info for how to handle the return.  This seems more complex than necessary right now, so we've
         //       left it here.
         /// <summary>
-        /// Builds a URI for a user to purchase Gloebits
+        /// Builds a URI for a user to purchase gloebits
         /// </summary>
         /// <param name="callbackBaseUri">Base URI for where the /gloebit/buy_complete/ path was registered.  Supplied in the purchase uri
         ///                               so we can let the platform know when a user has completed a purchase.  This alert is not
         ///                               yet implemented on the Gloebit server.</param>
-        /// <param name ="u">GloebitUser representing the agent and app requesting to purchase Gloebits</param>
-        /// <returns>URI for the platform to provide at which this user can purchase Gloebits.</returns>
+        /// <param name ="u">GloebitUser representing the agent and app requesting to purchase gloebits</param>
+        /// <returns>URI for the platform to provide at which this user can purchase gloebits.</returns>
         public Uri BuildPurchaseURI(Uri callbackBaseUri, GloebitUser u) {
             UriBuilder purchaseUri = new UriBuilder(m_url);
             purchaseUri.Path = "/purchase";
@@ -293,7 +293,7 @@ namespace Gloebit.GloebitMoneyModule {
         /*** GloebitAPI Optional HTTP Callback Entrance Point - must be registered by GMM to work - not yet implemented ***/
         /// <summary>
         /// NOT YET IMPLEMENTED BY GLOEBIT SERVICE
-        /// Used by the redirect-to parameter to GloebitAPI.Purchase.  Called when a user has finished purchasing Gloebits
+        /// Used by the redirect-to parameter to GloebitAPI.Purchase.  Called when a user has finished purchasing gloebits
         /// Sends a balance update to the user
         /// </summary>
         /// <param name="requestData">response data from GloebitAPI.Purchase</param>
@@ -321,7 +321,7 @@ namespace Gloebit.GloebitMoneyModule {
             return response;
         }
 
-        #endregion // Purchasing Gloebits
+        #endregion // Purchasing gloebits
 
         #region Transaction
 
@@ -628,7 +628,7 @@ namespace Gloebit.GloebitMoneyModule {
                             // Send dialog asking user to auth or report --- needs different message.
                             m_log.Info("[GLOEBITMONEYMODULE] TransactU2UCompleted - SUBSCRIPTION_AUTH_DECLINED - requesting SubAuth approval");
                             break;
-                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's Gloebit account is locked and not allowed to spend Gloebits */
+                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's Gloebit account is locked and not allowed to spend gloebits */
                             m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payer account locked.  id:{0}", tID);
                             break;
                         case GloebitAPI.TransactionFailure.PAYEE_CANNOT_BE_IDENTIFIED:            /* can not identify merchant from params supplied by app */
@@ -636,7 +636,7 @@ namespace Gloebit.GloebitMoneyModule {
                             break;
                         case GloebitAPI.TransactionFailure.PAYEE_CANNOT_RECEIVE:                  /* Seller's Gloebit account can not receive Gloebits */
                             // TODO: research if/when account is in this state.  Only by admin?  All accounts until merchants?
-                            m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payee account locked - can't receive Gloebits.  id:{0}", tID);
+                            m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payee account locked - can't receive gloebits.  id:{0}", tID);
                             break;
                         default:
                             // Shouldn't get here.

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
@@ -173,7 +173,7 @@ namespace Gloebit.GloebitMoneyModule {
             Uri url = BuildPurchaseURI(m_platformAccessors.GetBaseURI(), u);
             Hashtable response = new Hashtable();
             response["int_response_code"] = 200;
-            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need Gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
+            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend Gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need Gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
             response["content_type"] = "text/html";
 
             return response;
@@ -321,7 +321,7 @@ namespace Gloebit.GloebitMoneyModule {
             return response;
         }
 
-        #endregion // Purchasing gloebits
+        #endregion // Purchasing Gloebits
 
         #region Transaction
 
@@ -411,7 +411,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Submits a GloebitTransaction to gloebit for processing and provides any necessary feedback to user/platform.
+        /// Submits a GloebitTransaction to Gloebit for processing and provides any necessary feedback to user/platform.
         /// --- Must call buildTransaction() to create argument 1.
         /// --- Must call buildBaseTransactionDescMap() to create argument 3.
         /// </summary>
@@ -451,7 +451,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Submits a GloebitTransaction using synchronous web requests to gloebit for processing and provides any necessary feedback to user/platform.
+        /// Submits a GloebitTransaction using synchronous web requests to Gloebit for processing and provides any necessary feedback to user/platform.
         /// Rather than solely receiving a "submission" response, TransactU2UCallback happens during request, and receives transaction success/failure response.
         /// --- Must call buildTransaction() to create argument 1.
         /// --- Must call buildBaseTransactionDescMap() to create argument 3.
@@ -628,13 +628,13 @@ namespace Gloebit.GloebitMoneyModule {
                             // Send dialog asking user to auth or report --- needs different message.
                             m_log.Info("[GLOEBITMONEYMODULE] TransactU2UCompleted - SUBSCRIPTION_AUTH_DECLINED - requesting SubAuth approval");
                             break;
-                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's Gloebit account is locked and not allowed to spend gloebits */
+                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's Gloebit account is locked and not allowed to spend Gloebits */
                             m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payer account locked.  id:{0}", tID);
                             break;
                         case GloebitAPI.TransactionFailure.PAYEE_CANNOT_BE_IDENTIFIED:            /* can not identify merchant from params supplied by app */
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted Gloebit could not identify payee from params.  transactionID:{0} payeeID:{1}", tID, payeeUser.PrincipalID);
                             break;
-                        case GloebitAPI.TransactionFailure.PAYEE_CANNOT_RECEIVE:                  /* Seller's Gloebit account can not receive gloebits */
+                        case GloebitAPI.TransactionFailure.PAYEE_CANNOT_RECEIVE:                  /* Seller's Gloebit account can not receive Gloebits */
                             // TODO: research if/when account is in this state.  Only by admin?  All accounts until merchants?
                             m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payee account locked - can't receive Gloebits.  id:{0}", tID);
                             break;

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitAPIWrapper.cs
@@ -114,9 +114,9 @@ namespace Gloebit.GloebitMoneyModule {
          * GloebitUser.Get() should be called to create or retrieve an AppUser
          * --- There is not one central GloebitAPIWrapper function for starting a new user session
          * --- but it may later be centralized.
-         * --- See GMM.SendNewSessionMessaging() func for closest thing to a StartUserSession().
+         * --- See GMM.SendNewSessionMessaging() function for closest thing to a StartUserSession().
          * GloebitUser.Cleanup() should be called to free up memory when a User is no longer active
-         * calling GetUserBalance() func with forceAuthoOnInvalidToken=true
+         * calling GetUserBalance() function with forceAuthoOnInvalidToken=true
          * --- is simplest way to ensure user is authorized and ready to proceed with transactions.
          ***************/
 
@@ -173,7 +173,7 @@ namespace Gloebit.GloebitMoneyModule {
             Uri url = BuildPurchaseURI(m_platformAccessors.GetBaseURI(), u);
             Hashtable response = new Hashtable();
             response["int_response_code"] = 200;
-            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
+            response["str_response_string"] = String.Format("<html><head><title>Gloebit authorized</title></head><body><h2>Gloebit authorized</h2>Thank you for authorizing Gloebit.  You may now close this window and return to OpenSim.<br /><br /><br />You'll now be able spend gloebits from your Gloebit account as the agent you authorized on this OpenSim Grid.<br /><br />If you need Gloebits, you can <a href=\"{0}\">purchase them here</a>.</body></html>", url);
             response["content_type"] = "text/html";
 
             return response;
@@ -209,14 +209,14 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Retrieves the gloebit balance of the Gloebit account linked to the user defined by the userIDOnApp.
+        /// Retrieves the Gloebit balance of the Gloebit account linked to the user defined by the userIDOnApp.
         /// If there is no token, or an invalid token on file, and forceAuthOnInvalidToken is true, we request authorization from the AppUser.
         /// If we request authorization, the userName is provided to that API Authorize function.  Otherwise, it is not used.
         /// </summary>
         /// <param name="userIDOnApp">ID from this app for the user whose balance is being requested</param>
         /// <param name ="forceAuthOnInvalidToken">Bool indicating whether we should request auth on failures from lack of auth</param>
         /// <param name="userName">string name of the user in this application.</param>
-        /// <returns>Gloebit balance for the gloebit account linked to this user or 0.0.</returns>
+        /// <returns>Gloebit balance for the Gloebit account linked to this user or 0.0.</returns>
         public double GetUserBalance(UUID userIDOnApp, bool forceAuthOnInvalidToken, string userName)
         {
             m_log.DebugFormat("[GLOEBITMONEYMODULE] GetAppUserBalance userIDOnApp:{0}", userIDOnApp);
@@ -258,23 +258,23 @@ namespace Gloebit.GloebitMoneyModule {
                    
         /******************
          * Users can do this directly from their Gloebit account on the website, so these methods are not required.
-         * However, they are useful for providing gloebit purchase links to the user to take them directly to the purchase page.
+         * However, they are useful for providing Gloebit purchase links to the user to take them directly to the purchase page.
          * Eventually, these links will enable returning directly to a commerce flow or alerting the app that the user's balance
          * has been updated.
          ******************/
 
-        // TODO: should this be moved to API and replaced with purchase func here which builds and calls send with URI?
+        // TODO: should this be moved to API and replaced with purchase function here which builds and calls send with URI?
         //       GMM definitely needs to just build the URI, though it could call purchase when it needs it for a link and not send it
         //       if it can supply extra info for how to handle the return.  This seems more complex than necessary right now, so we've
         //       left it here.
         /// <summary>
-        /// Builds a URI for a user to purchase gloebits
+        /// Builds a URI for a user to purchase Gloebits
         /// </summary>
         /// <param name="callbackBaseUri">Base URI for where the /gloebit/buy_complete/ path was registered.  Supplied in the purchase uri
         ///                               so we can let the platform know when a user has completed a purchase.  This alert is not
         ///                               yet implemented on the Gloebit server.</param>
-        /// <param name ="u">GloebitUser representing the agent and app requesting to purchase gloebits</param>
-        /// <returns>URI for the platform to provide at which this user can purchase gloebits.</returns>
+        /// <param name ="u">GloebitUser representing the agent and app requesting to purchase Gloebits</param>
+        /// <returns>URI for the platform to provide at which this user can purchase Gloebits.</returns>
         public Uri BuildPurchaseURI(Uri callbackBaseUri, GloebitUser u) {
             UriBuilder purchaseUri = new UriBuilder(m_url);
             purchaseUri.Path = "/purchase";
@@ -293,7 +293,7 @@ namespace Gloebit.GloebitMoneyModule {
         /*** GloebitAPI Optional HTTP Callback Entrance Point - must be registered by GMM to work - not yet implemented ***/
         /// <summary>
         /// NOT YET IMPLEMENTED BY GLOEBIT SERVICE
-        /// Used by the redirect-to parameter to GloebitAPI.Purchase.  Called when a user has finished purchasing gloebits
+        /// Used by the redirect-to parameter to GloebitAPI.Purchase.  Called when a user has finished purchasing Gloebits
         /// Sends a balance update to the user
         /// </summary>
         /// <param name="requestData">response data from GloebitAPI.Purchase</param>
@@ -333,7 +333,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Helper function to build the minimal transaction description sent to the Gloebit transactU2U endpoint.
         /// Used for tracking as well as information provided in transaction histories.
         /// </summary>
-        /// <param name="txnType">String describing the type of transaction.  eg. ObjectBuy, PayObject, PayUser, etc.</param>
+        /// <param name="txnType">String describing the type of transaction.  e.g. ObjectBuy, PayObject, PayUser, etc.</param>
         /// <returns>OSDMap to be sent with the transaction request parameters.  Map contains six dictionary entries, each including an OSDArray.</returns>
         public OSDMap BuildBaseTransactionDescMap(string txnType)
         {
@@ -362,7 +362,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Any entryName/Value pairs added to a descMap passed to the transactU2U endpoint will be sent to Gloebit, tracked with the transaction, and will appear in the transaction history for all users who are a party to the transaction.
         /// </summary>
         /// <param name="descMap">descMap created by buildBaseTransactionDescMap.</param>
-        /// <param name="entryGroup">String group to which to add entryName/Value pair.  Must be one of {"platform", "location", "transactino"}.  Specifies group to which these details are most applicable.</param>
+        /// <param name="entryGroup">String group to which to add entryName/Value pair.  Must be one of {"platform", "location", "transaction"}.  Specifies group to which these details are most applicable.</param>
         /// <param name="entryName">String providing the name for entry to be added.  This is the name users will see in their transaction history for this entry.</param>
         /// <param name="entryValue">String providing the value for entry to be added.  This is the value users will see in their transaction history for this entry.</param>
         public void AddDescMapEntry(OSDMap descMap, string entryGroup, string entryName, string entryValue)
@@ -404,7 +404,7 @@ namespace Gloebit.GloebitMoneyModule {
                     break;
                 default:
                     // SHOULD NEVER GET HERE
-                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] addDescMapEntry: Attempted to add a transaction description parameter in an entryGroup that is not be tracked by Gloebit and made it to defualt of switch statement.  entryGroup:{0} permittedGroups:{1} entryName:{2} entryValue:{3}", entryGroup, permittedGroups, entryName, entryValue);
+                    m_log.ErrorFormat("[GLOEBITMONEYMODULE] addDescMapEntry: Attempted to add a transaction description parameter in an entryGroup that is not be tracked by Gloebit and made it to default of switch statement.  entryGroup:{0} permittedGroups:{1} entryName:{2} entryValue:{3}", entryGroup, permittedGroups, entryName, entryValue);
                     break;
             }
             return;
@@ -417,7 +417,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </summary>
         /// <param name="txn">GloebitTransaction created from buildTransaction().  Contains vital transaction details.</param>
         /// <param name="description">Description of transaction for transaction history reporting.</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <param name="u2u">boolean declaring whether this is a user-to-app (false) or user-to-user (true) transaction.</param>
         /// <returns>
         /// true if async transactU2U web request was built and submitted successfully; false if failed to submit request.
@@ -430,7 +430,7 @@ namespace Gloebit.GloebitMoneyModule {
             m_log.InfoFormat("[GLOEBITMONEYMODULE] SubmitTransaction Txn: {0}, from {1} to {2}, for amount {3}, transactionType: {4}, description: {5}", txn.TransactionID, txn.PayerID, txn.PayeeID, txn.Amount, txn.TransactionType, description);
             m_transactionAlerts.AlertTransactionBegun(txn, description);
 
-            // TODO: Update all the alert funcs to handle fees properly.
+            // TODO: Update all the alert functions to handle fees properly.
 
             // TODO: Should we wrap TransactU2U or request.BeginGetResponse in Try/Catch?
             bool result = false;
@@ -451,7 +451,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Submits a GloebitTransaction usings synchronous web requests to gloebit for processing and provides any necessary feedback to user/platform.
+        /// Submits a GloebitTransaction using synchronous web requests to gloebit for processing and provides any necessary feedback to user/platform.
         /// Rather than solely receiving a "submission" response, TransactU2UCallback happens during request, and receives transaction success/failure response.
         /// --- Must call buildTransaction() to create argument 1.
         /// --- Must call buildBaseTransactionDescMap() to create argument 3.
@@ -459,7 +459,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </summary>
         /// <param name="txn">GloebitTransaction created from buildTransaction().  Contains vital transaction details.</param>
         /// <param name="description">Description of transaction for transaction history reporting.</param>
-        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaciton history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
+        /// <param name="descMap">Map of platform, location & transaction descriptors for tracking/querying and transaction history details.  For more details, <see cref="GloebitMoneyModule.buildBaseTransactionDescMap"/> helper function.</param>
         /// <returns>
         /// true if sync transactU2U web request was built and submitted successfully and Gloebit components of transaction were enacted successfully.
         /// false if failed to submit request or if txn failed at any stage prior to successfully enacting Gloebit txn components.
@@ -483,7 +483,7 @@ namespace Gloebit.GloebitMoneyModule {
             if (!result) {
                 m_log.ErrorFormat("[GLOEBITMONEYMODULE] SubmitSyncTransaction failed in stage: {0} with failure: {1}", stage, failure);
                 if (stage == GloebitAPI.TransactionStage.SUBMIT) {
-                    // currently need to handle these errors here as the TransactU2UCallback is not called unless sumission is successful and we receive a response
+                    // currently need to handle these errors here as the TransactU2UCallback is not called unless submission is successful and we receive a response
                     m_transactionAlerts.AlertTransactionFailed(txn, GloebitAPI.TransactionStage.SUBMIT, failure, String.Empty, new OSDMap());
                 }
             } else {
@@ -500,7 +500,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// If this was successful, then the transaction was submitted and queued and the monetary pieces
         /// of the transaction were each enacted by the server.  The transaction processor will re-enact those
         /// and call enact/cancel/consume on the local asset / transaction part.
-        /// This function parses the repsonse from Gloebit, logs useful information, and calls ITransactionAlert
+        /// This function parses the response from Gloebit, logs useful information, and calls ITransactionAlert
         /// interface functions with the data needed by the platform for any processing.
         /// </summary>
         /// <param name="success">bool - if true, the exchange was successful and this user is authorized and linked to a Gloebit account</param>
@@ -561,7 +561,7 @@ namespace Gloebit.GloebitMoneyModule {
                     // TODO: Should we send a failure alert here?  Could transaction enact successfully?  Need to research this
                     // insufficient-balance; pending probably can't occur; something new?
                     if (failure == GloebitAPI.TransactionFailure.INSUFFICIENT_FUNDS) {
-                        m_log.InfoFormat("[GLOEBITMONEYMODULE].transactU2UCompleted transaction failed.  Buyer has insufficent funds.  id:{0}", tID);
+                        m_log.InfoFormat("[GLOEBITMONEYMODULE].transactU2UCompleted transaction failed.  Buyer has insufficient funds.  id:{0}", tID);
                     } else {
                         // unhandled, so pass reason
                         m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted transaction failed during processing.  reason:{0} id:{1} failure:{2}", reason, tID, failure);
@@ -628,15 +628,15 @@ namespace Gloebit.GloebitMoneyModule {
                             // Send dialog asking user to auth or report --- needs different message.
                             m_log.Info("[GLOEBITMONEYMODULE] TransactU2UCompleted - SUBSCRIPTION_AUTH_DECLINED - requesting SubAuth approval");
                             break;
-                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's gloebit account is locked and not allowed to spend gloebits */
+                        case GloebitAPI.TransactionFailure.PAYER_ACCOUNT_LOCKED:                  /* Buyer's Gloebit account is locked and not allowed to spend gloebits */
                             m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payer account locked.  id:{0}", tID);
                             break;
                         case GloebitAPI.TransactionFailure.PAYEE_CANNOT_BE_IDENTIFIED:            /* can not identify merchant from params supplied by app */
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted Gloebit could not identify payee from params.  transactionID:{0} payeeID:{1}", tID, payeeUser.PrincipalID);
                             break;
-                        case GloebitAPI.TransactionFailure.PAYEE_CANNOT_RECEIVE:                  /* Seller's gloebit account can not receive gloebits */
+                        case GloebitAPI.TransactionFailure.PAYEE_CANNOT_RECEIVE:                  /* Seller's Gloebit account can not receive gloebits */
                             // TODO: research if/when account is in this state.  Only by admin?  All accounts until merchants?
-                            m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payee account locked - can't receive gloebits.  id:{0}", tID);
+                            m_log.InfoFormat("[GLOEBITMONEYMODULE] transactU2UCompleted - FAILURE -- payee account locked - can't receive Gloebits.  id:{0}", tID);
                             break;
                         default:
                             // Shouldn't get here.
@@ -661,7 +661,7 @@ namespace Gloebit.GloebitMoneyModule {
                     }
                     break;
                 default:
-                    m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted unhandled Transaciton Stage:{0} failure:{1}  transactionID:{2}", stage, failure, tID);
+                    m_log.ErrorFormat("[GLOEBITMONEYMODULE].transactU2UCompleted unhandled Transaction Stage:{0} failure:{1}  transactionID:{2}", stage, failure, tID);
                     additionalDetailStr = reason;
                     break;
             }
@@ -682,7 +682,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </summary>
         /// <param name="requestData">GloebitAPI.Asset enactHoldURI, consumeHoldURI or cancelHoldURI query arguments tying this callback to a specific Asset.</param>
         /// <returns>
-        /// Web respsponse including JSON array of one or two elements.  First element is bool representing success state of call.
+        /// Web response including JSON array of one or two elements.  First element is bool representing success state of call.
         /// --- If first element is false, the second element is a string providing the reason for failure.
         /// --- If the second element is "pending", then the transaction processor will retry.
         /// --- All other reasons are considered permanent failure.
@@ -796,7 +796,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// If this was successful, then the subscription was created on the server and the GloebitAPI
         /// has recorded the id of the subscription on the server into the SubscriptionID field of the
         /// local subscription and marked it enabled.
-        /// This function parses the repsonse from Gloebit, logs useful information, and calls ISubscriptionAlert
+        /// This function parses the response from Gloebit, logs useful information, and calls ISubscriptionAlert
         /// interface functions with the data needed by the platform for any processing.
         /// </summary>
         /// <param name="responseDataMap">OSDMap of response data from GloebitAPI.CreateSubscription</param>
@@ -827,7 +827,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Ask user to authorize a subscription for an agent on an app linked to thier Gloebit account.
+        /// Ask user to authorize a subscription for an agent on an app linked to their Gloebit account.
         /// This builds the URI which must be loaded for the user to take action.
         /// The subscription authorization must be created first if this has not already been done.
         /// Once created, The user can also authorize or decline it on their own from the Subscriptions 
@@ -848,7 +848,7 @@ namespace Gloebit.GloebitMoneyModule {
         }
 
         /// <summary>
-        /// Ask user to authorize a subscription for an agent on an app linked to thier Gloebit account.
+        /// Ask user to authorize a subscription for an agent on an app linked to their Gloebit account.
         /// This builds the URI which must be loaded for the user to take action.
         /// The subscription authorization must be created first if this has not already been done.
         /// Once created, The user can also authorize or decline it on their own from the Subscriptions 
@@ -881,7 +881,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// Called by the GloebitAPI after the async call to CreateSubscriptionAuthorization completes.
         /// If this was successful, then the subscription authorization was created or located on the Gloebit service
         /// and the ID of the subscription authorization was returned in the response.
-        /// This function parses the repsonse from Gloebit, logs useful information, builds the 
+        /// This function parses the response from Gloebit, logs useful information, builds the 
         /// URI where the user can authorize the subscription, and asks the platform to send that
         /// URI to the user.
         /// </summary>
@@ -948,7 +948,7 @@ namespace Gloebit.GloebitMoneyModule {
         /// </summary>
         /// <param name="user">GloebitUser we are sending the URL to</param>
         /// <param name="subAuthID">ID of the authorization request the user will be asked to approve - provided by Gloebit.</param>
-        /// <param name="sub">GloebitSubscription which containes necessary details for message to user.</param>
+        /// <param name="sub">GloebitSubscription which contains necessary details for message to user.</param>
         /// <param name="isDeclined">Bool is true if this sub auth has already been declined by the user which should present different messaging.</param>
         private void SendSubscriptionAuthorizationToUser(GloebitUser user, string subAuthID, GloebitSubscription sub, bool isDeclined)
         {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -1035,7 +1035,7 @@ namespace Gloebit.GloebitMoneyModule
             double balance = 0.0;
             
             // force a balance update, then check against amount.
-            // Retrieve balance from Gloebit if authed.  Reqeust auth if not authed.  Send purchase url if authed but lacking funds to cover amount.
+            // Retrieve balance from Gloebit if authed.  Request auth if not authed.  Send purchase url if authed but lacking funds to cover amount.
             balance = UpdateBalance(agentID, client, amount);
             
             if (balance < amount) {
@@ -1562,7 +1562,7 @@ namespace Gloebit.GloebitMoneyModule
             // Build universal base OpenSim descMap
             OSDMap descMap = buildOpenSimTransactionDescMap(regionname, regionID, txnType);
 
-            // Add base descMap details for transaciton involving an object/part
+            // Add base descMap details for transaction involving an object/part
             if (descMap != null && part != null) {
                 m_apiW.AddDescMapEntry(descMap, "location", "object-group-position", part.GroupPosition.ToString());
                 m_apiW.AddDescMapEntry(descMap, "location", "object-absolute-position", part.AbsolutePosition.ToString());
@@ -1591,7 +1591,7 @@ namespace Gloebit.GloebitMoneyModule
             // Build universal base descMap
             OSDMap descMap = buildOpenSimTransactionDescMap(regionname, regionID, txnType);
 
-            // Add base descMap details for transaciton involving an object/part
+            // Add base descMap details for transaction involving an object/part
             if (descMap != null && pld != null) {
                 m_apiW.AddDescMapEntry(descMap, "location", "parcel-upper-corner-position", pld.AABBMax.ToString());
                 m_apiW.AddDescMapEntry(descMap, "location", "parcel-lower-corner-position", pld.AABBMin.ToString());

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -387,7 +387,20 @@ namespace Gloebit.GloebitMoneyModule
                 /*** Get GloebitMoneyModule configuration details ***/
                 // Is Gloebit disabled, enabled across the entire sim process, or on certain regions?
                 bool enabled = config.GetBoolean("Enabled", false);
-                m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
+				
+				m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
+				
+				// Should we send popups to users or not, some find them annoying especially if they are not using the system
+				bool sendpopups = config.GetBoolean("SendPopups", true);
+				
+				if (sendpopups == false)
+				{
+					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send popups to users!");
+				} else {
+					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
+				}
+				
+				
                 m_enabled = m_enabled && enabled;
                 if (!m_enabled) {
                     m_log.Info("[GLOEBITMONEYMODULE] Not enabled globally for sim. (to enable set \"Enabled = true\" in [Gloebit] and \"economymodule = Gloebit\" in [Economy])");
@@ -1928,7 +1941,8 @@ namespace Gloebit.GloebitMoneyModule
             IClientAPI client = LocateClientObject(UUID.Parse(user.PrincipalID));
             string title = "AUTHORIZE GLOEBIT";
             string body = "To use Gloebit currency, please authorize Gloebit to link to your avatar's account on this web page:";
-            SendUrlToClient(client, title, body, authorizeUri);
+			if (sendpopups)
+				SendUrlToClient(client, title, body, authorizeUri);
         }
 
         /// <summary>

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -204,6 +204,10 @@ namespace Gloebit.GloebitMoneyModule
         private string m_opensimVersionNumber = String.Empty;
         private bool m_newLandPassFlow = false;
 		private bool m_newHTTPFlow = false;
+		
+		// Allow overriding of versions in case version number can't be identified
+		private bool m_FnewLandPassFlow = false;
+		private bool m_FnewHTTPFlow = false;
 
 
         #region IRegionModuleBase Interface
@@ -405,6 +409,11 @@ namespace Gloebit.GloebitMoneyModule
 				} else {
 					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
 				}
+				
+				// If version cannot be detected override workflow selection via config
+				// Currently not documented because last resort if all version checking fails
+				m_FnewLandPassFlow = config.GetBoolean("GLBNewLandPassFlow", false);
+				m_FnewHTTPFlow = config.GetBoolean("GLBNewHTTPFlow", false);
 				
                 m_enabled = m_enabled && enabled;
                 if (!m_enabled) {
@@ -691,14 +700,18 @@ namespace Gloebit.GloebitMoneyModule
 		// TODO: Find a better method to do version testing, do not rely on version number, it can be edited easily and does not reflect code
         public void PostInitialise()
         {
-			int vn1 = 0;
-			int vn2 = 0;
-			int vn3 = 0;
+			// Setting to large negative so if not found is not 0
+			int vn1 = -9999;
+			int vn2 = -9999;
+			int vn3 = -9999;
 			int vn4 = -9999;
+			string detectedOSVersion;
             m_opensimVersion = OpenSim.VersionInfo.Version;
             m_opensimVersionNumber = OpenSim.VersionInfo.VersionNumber;
             char[] delimiterChars = { '.' };
             string[] numbers = m_opensimVersionNumber.Split(delimiterChars, System.StringSplitOptions.RemoveEmptyEntries);
+			
+			// See if we can parse the string at all
 			try {
 				vn1 = int.Parse(numbers[0]);
 				vn2 = int.Parse(numbers[1]);
@@ -706,43 +719,76 @@ namespace Gloebit.GloebitMoneyModule
 			} catch {
 				m_log.DebugFormat("[GLOEBITMONEYMODULE] Unable to parse version information, Gloebit cannot handle unofficial versions");
 			}
+			// Fourth number may not be present on all versions
 			try {
 					vn4 = int.Parse(numbers[3]);
 				}
 			catch {}
 			
-            if ((vn1 > 0) || (vn2 > 9) || (vn2 == 9 && vn3 > 0)) {
+			// This is a really poor way of detecting versions, instead the capabilities of functions and httpserver should be tested directly to determine which workflows to use!!!		
+            if ((vn1 > 0) || (vn2 > 9) || (vn2 == 9 && vn3 > 0)) 
+			{
                 // 0.9.1 and beyond are the new land pass flow.
                 // Note, there are some early versions of 0.9.1 before any release candidate which do not have the new
                 // flow, but we can't easily determine those and no one should be running those in production.
+				detectedOSVersion = "=>0.9.1";
                 m_newLandPassFlow = true;
-            } else if (vn1 == 0 && vn2 == 9 && vn3 == 0) {
+				if ((vn2 == 9) && (vn3 == 2 || vn3 > 2) && (vn4 == 0 || vn4 > 0)) 
+				{
+					// Test for version 0.9.2.0 and beyond which contains changes to httpserver and thus needs different workflows also
+					detectedOSVersion = "=>0.9.2.0";
+					m_newLandPassFlow = true;
+					m_newHTTPFlow = true;
+				}
+            }
+			else if (vn1 == 0 && vn2 == 9 && vn3 == 0)
+			{
                 // 0.9.0-release pulled in 0.9.1 changes and is new flow, but rest of 0.9.0 is not.
                 // assume dev on 0.9.0.1, 0.9.0.2 will be new flow
-                if (vn4 > 0) {
+                if (vn4 > 0)
+				{
                     // 0.9.0.1, 0.9.0.2, etc.
+					detectedOSVersion = "=>0.9.0.1";
                     m_newLandPassFlow = true;
-                } else {
+                }
+				else
+				{
                     // Need to pull version flavour and check it.
                     // TODO: may need to split on spaces or hyphens and then pull last field because flavour is not friggin public
                     char[] dChars = { '-', ' ' };
                     string[] versionParts = m_opensimVersion.Split(dChars, System.StringSplitOptions.RemoveEmptyEntries);
                     string flavour = versionParts[versionParts.Length - 1];     // TODO: do we every have to worry about this being length 0?
-                    if (flavour == OpenSim.VersionInfo.Flavour.Release.ToString()) {
+                    if (flavour == OpenSim.VersionInfo.Flavour.Release.ToString())
+					{
                         // 0.9.0 release
+						detectedOSVersion = "=0.9.0";
                         m_newLandPassFlow = true;
                     }
                 }
                 // TODO: Unclear if post-fixes is a necessary flavour check yet.
             }
-			
-			// Test for version 0.9.2.0 which contains changes to httpserver and thus needs different workflows also
-			// This is a really bad way to check which method to use as these changes are not directly related to version numbers
-			// Rather these changes also concern libomv and should be tested for by directly testing available methods of httpserver
-			if (((vn2 == 9 && vn3 == 2) || (vn2 > 9 && vn3 > 2)) && vn4 != -9999)
+			else
 			{
+				// If all else fails version is unknown
+				detectedOSVersion = "unknown";
+				m_log.DebugFormat("[GLOEBITMONEYMODULE] Could not determine OpenSim version or unknown version, module may not function! Use config overrides!");		
+			}
+			
+			// If version is unknown or changed by user allow override via config	
+			if (m_FnewHTTPFlow == true)
+			{
+				m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new HTTP Flow, set by config");
 				m_newHTTPFlow = true;
 			}
+			
+			if (m_FnewLandPassFlow == true)
+			{
+				m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new LandPass Flow, set by config");
+				m_newLandPassFlow = true;
+			}			
+			
+			// Provide detailed feedback on which version is detected, for debugging and information
+			m_log.DebugFormat("[GLOEBITMONEYMODULE] OpenSim version {0} present, detected: {1} Using New LandPass Flow: {3} Using New HTTP Flow {4}", m_opensimVersionNumber, detectedOSVersion, m_newLandPassFlow, m_newHTTPFlow);
         }
         
         #endregion // ISharedRegionModule Interface

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -135,7 +135,7 @@ namespace Gloebit.GloebitMoneyModule
         // Set to false if anything is misconfigured
         private bool m_configured = true;
 		// Configure true if not present
-		private bool sendpopups = true;
+		private bool m_showWelcomeMessage = true;
         
         // Populated from Gloebit.ini
         private UUID[] m_enabledRegions = null;         // Regions on sim to individually enable GMM.
@@ -397,11 +397,11 @@ namespace Gloebit.GloebitMoneyModule
 				m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
 				
 				// Should we send popups to users or not, some find them annoying especially if they are not using the system
-				sendpopups = config.GetBoolean("SendPopups", true);
+				m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
 				
-				if (sendpopups == false)
+				if (m_showWelcomeMessage == false)
 				{
-					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send popups to users!");
+					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send welcome message to users!");
 				} else {
 					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
 				}
@@ -1986,11 +1986,7 @@ namespace Gloebit.GloebitMoneyModule
             string title = "AUTHORIZE GLOEBIT";
             string body = "To use Gloebit currency, please authorize Gloebit to link to your avatar's account on this web page:";
 			
-			// Some find these popups annoying especially if they don't want to use Gloebit on their region so we just don't send them popups
-			// Gloebit is still enabled and users who already authed themselves can use it, but it won't nag anyone to register
-			// A forever dismiss until the balance is clicked again would work better, but is a lot harder to implement
-			if (sendpopups)
-				SendUrlToClient(client, title, body, authorizeUri);
+			SendUrlToClient(client, title, body, authorizeUri);
         }
 
         /// <summary>
@@ -3512,9 +3508,10 @@ namespace Gloebit.GloebitMoneyModule
             Thread welcomeMessageThread = new Thread(delegate() {
                 Thread.Sleep(delay * 1000);  // Delay milliseconds
                 // Deliver welcome message if we have popups enabled
-				if (sendpopups)
+				if (m_showWelcomeMessage)
 					sendMessageToClient(client, msg, client.AgentId);
-                // If authed, delivery url where user can purchase Gloebits
+				
+				// If authed, delivery url where user can purchase Gloebits
                 if (user.IsAuthed()) {
                     if (m_showNewSessionPurchaseIM) {
                         Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -434,9 +434,9 @@ namespace Gloebit.GloebitMoneyModule
                 // Should we send a welcome message informing user that Gloebit is enabled
                 m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
                 string nsms_msg = "\n\t";
-                nsms_msg = String.Format("{0}Welcome Message: {1},\tTo modify, set m_showWelcomeMessage in [Gloebit] section of config\n\t", nsms_msg, m_showWelcomeMessage);
-                nsms_msg = String.Format("{0}Auth Message: {1},\tTo modify, set m_showNewSessionAuthIM in [Gloebit] section of config\n\t", nsms_msg, m_showNewSessionAuthIM);
-                nsms_msg = String.Format("{0}Purchase Message: {1},\tTo modify, set m_showNewSessionPurchaseIM in [Gloebit] section of config", nsms_msg, m_showNewSessionPurchaseIM);
+                nsms_msg = String.Format("{0}Welcome Message: {1},\tTo modify, set GLBShowWelcomeMessage in [Gloebit] section of config\n\t", nsms_msg, m_showWelcomeMessage);
+                nsms_msg = String.Format("{0}Auth Message: {1},\tTo modify, set GLBShowNewSessionAuthIM in [Gloebit] section of config\n\t", nsms_msg, m_showNewSessionAuthIM);
+                nsms_msg = String.Format("{0}Purchase Message: {1},\tTo modify, set GLBShowNewSessionPurchaseIM in [Gloebit] section of config", nsms_msg, m_showNewSessionPurchaseIM);
                 m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] is configured with the following settings for messaging users connecting to a new session{0}", nsms_msg);
                 // If version cannot be detected override workflow selection via config
                 // Currently not documented because last resort if all version checking fails

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -705,7 +705,7 @@ namespace Gloebit.GloebitMoneyModule
 			int vn2 = -9999;
 			int vn3 = -9999;
 			int vn4 = -9999;
-			string detectedOSVersion;
+			string detectedOSVersion = "unknown";
             m_opensimVersion = OpenSim.VersionInfo.Version;
             m_opensimVersionNumber = OpenSim.VersionInfo.VersionNumber;
             char[] delimiterChars = { '.' };

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -788,7 +788,7 @@ namespace Gloebit.GloebitMoneyModule
 			}			
 			
 			// Provide detailed feedback on which version is detected, for debugging and information
-			m_log.DebugFormat("[GLOEBITMONEYMODULE] OpenSim version {0} present, detected: {1} Using New LandPass Flow: {3} Using New HTTP Flow {4}", m_opensimVersionNumber, detectedOSVersion, m_newLandPassFlow, m_newHTTPFlow);
+			m_log.DebugFormat("[GLOEBITMONEYMODULE] OpenSim version {0} present, detected: {1} Using New LandPass Flow: {2} Using New HTTP Flow {3}", m_opensimVersionNumber.ToString(), detectedOSVersion.ToString(), m_newLandPassFlow.ToString(), m_newHTTPFlow.ToString());
         }
         
         #endregion // ISharedRegionModule Interface

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -400,21 +400,6 @@ namespace Gloebit.GloebitMoneyModule
                 
                 m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
 
-                // Should we send popups to users or not, some find them annoying especially if they are not using the system
-                m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
-
-                if (m_showWelcomeMessage == false)
-                {
-                    m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send welcome message to users!");
-                } else {
-                    m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
-                }
-
-                // If version cannot be detected override workflow selection via config
-                // Currently not documented because last resort if all version checking fails
-                m_FnewLandPassFlow = config.GetBoolean("GLBNewLandPassFlow", false);
-                m_FnewHTTPFlow = config.GetBoolean("GLBNewHTTPFlow", false);
-
                 m_enabled = m_enabled && enabled;
                 if (!m_enabled) {
                     m_log.Info("[GLOEBITMONEYMODULE] Not enabled globally for sim. (to enable set \"Enabled = true\" in [Gloebit] and \"economymodule = Gloebit\" in [Economy])");
@@ -446,6 +431,17 @@ namespace Gloebit.GloebitMoneyModule
                 // Should we send new session IMs informing user how to auth or purchase gloebits
                 m_showNewSessionPurchaseIM = config.GetBoolean("GLBShowNewSessionPurchaseIM", false);
                 m_showNewSessionAuthIM = config.GetBoolean("GLBShowNewSessionAuthIM", true);
+                // Should we send a welcome message informing user that Gloebit is enabled
+                m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
+                string nsms_msg = "\n\t";
+                nsms_msg = String.Format("{0}Welcome Message: {1},\tTo modify, set m_showWelcomeMessage in [Gloebit] section of config\n\t", nsms_msg, m_showWelcomeMessage);
+                nsms_msg = String.Format("{0}Auth Message: {1},\tTo modify, set m_showNewSessionAuthIM in [Gloebit] section of config\n\t", nsms_msg, m_showNewSessionAuthIM);
+                nsms_msg = String.Format("{0}Purchase Message: {1},\tTo modify, set m_showNewSessionPurchaseIM in [Gloebit] section of config", nsms_msg, m_showNewSessionPurchaseIM);
+                m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] is configured with the following settings for messaging users connecting to a new session{0}", nsms_msg);
+                // If version cannot be detected override workflow selection via config
+                // Currently not documented because last resort if all version checking fails
+                m_FnewLandPassFlow = config.GetBoolean("GLBNewLandPassFlow", false);
+                m_FnewHTTPFlow = config.GetBoolean("GLBNewHTTPFlow", false);
                 // Are we using custom db connection info
                 m_dbProvider = config.GetString("GLBSpecificStorageProvider");
                 m_dbConnectionString = config.GetString("GLBSpecificConnectionString");
@@ -3553,9 +3549,10 @@ namespace Gloebit.GloebitMoneyModule
             }
             Thread welcomeMessageThread = new Thread(delegate() {
                 Thread.Sleep(delay * 1000);  // Delay milliseconds
-                // Deliver welcome message if we have popups enabled
-                if (m_showWelcomeMessage)
+                // Deliver welcome message if we have welcome popup enabled
+                if (m_showWelcomeMessage) {
                     sendMessageToClient(client, msg, client.AgentId);
+                }
 
                 // If authed, delivery url where user can purchase Gloebits
                 if (user.IsAuthed()) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -545,7 +545,7 @@ namespace Gloebit.GloebitMoneyModule
                     if (m_scenel.Count == 0)
                     {
                         /*
-                         * For land sales, buy-currency button, and the insufficent funds flows to operate,
+                         * For land sales, buy-currency button, and the insufficient funds flows to operate,
                          * the economy helper uri needs to be present.
                          * 
                          * The GMM provides this helper-uri and the currency symbol via the OpenSim Extras.  
@@ -700,7 +700,7 @@ namespace Gloebit.GloebitMoneyModule
         // Dummy IMoneyModule interface which is not yet used.
         public void MoveMoney(UUID fromAgentID, UUID toAgentID, int amount, string text)
         {
-            // Call the newer MoveMoney funciton with a transaction type and text string so that we report
+            // Call the newer MoveMoney function with a transaction type and text string so that we report
             // errors on whatever this unimplemented transaction flow is.
             MoveMoney(fromAgentID, toAgentID, amount, (MoneyTransactionType)TransactionType.MOVE_MONEY_GENERAL, text);
         }
@@ -891,7 +891,7 @@ namespace Gloebit.GloebitMoneyModule
             GloebitSubscription sub = GloebitSubscription.Get(objectID, m_key, m_apiUrl);
             if (sub == null || sub.SubscriptionID == UUID.Zero) {
                 // null means we haven't attempted creation yet
-                // SubscriptionID == UUID.Zero means we have a local sub, but havent created this on Gloebit through API.  Likely a previous creation request failed
+                // SubscriptionID == UUID.Zero means we have a local sub, but haven't created this on Gloebit through API.  Likely a previous creation request failed
                 // In either case, we need to create a subscription on Gloebit before proceeding
 
                 // Message to user that we are creating the subscription.
@@ -921,7 +921,7 @@ namespace Gloebit.GloebitMoneyModule
                 // call api to submit creation request to Gloebit
                 m_apiW.CreateSubscription(objectID, part.Name, part.Description);
 
-                // return false so this the current transaciton terminates and object is alerted to failure
+                // return false so this the current transaction terminates and object is alerted to failure
                 reason = "Owner has not yet created a subscription.";
                 return false;   // Async creating sub.  when it returns, we'll continue flow in SubscriptionCreationCompleted
             }
@@ -1223,9 +1223,9 @@ namespace Gloebit.GloebitMoneyModule
          * GloebitUser.Get() should be called to create or retrieve an AppUser
          * --- There is not one central GMM function for this as it is done throughout the
          * --- GMM, but it may later be centralized.
-         * --- See SendNewSessionMessaging() func for closest thing to a StartUserSession().
+         * --- See SendNewSessionMessaging() function for closest thing to a StartUserSession().
          * GloebitUser.Cleanup() should be called to free up memory when a User is no longer active
-         * calling UpdateBalance() or m_apiW.GetUserBalance() func with forceAuthoOnInvalidToken=true
+         * calling UpdateBalance() or m_apiW.GetUserBalance() function with forceAuthoOnInvalidToken=true
          * --- is simplest way to ensure user is authorized and ready to proceed with transactions.
          ***************/
 
@@ -1303,7 +1303,7 @@ namespace Gloebit.GloebitMoneyModule
          * 2. Handle TransactionPrecheckFailures
          *    Define any newly necessary TransactionPrecheckFailure enums not already created.
          *    Call alertUsersTransactionPreparationFailure() as necessary from the interface function handling processing.
-         *    Edit alertUsersTransactionPrepartionFailure() as neccessary to provide specific messaging for this new TransactionType.
+         *    Edit alertUsersTransactionPrepartionFailure() as necessary to provide specific messaging for this new TransactionType.
          * 3. Compile info to be supplied in user's transaction history on gloebit.com 
          *    Call buildOpenSimTransactionDescMap
          *    If more info is needed, either create a new override for buildOpenSimTransactionDescMap, or
@@ -1322,7 +1322,7 @@ namespace Gloebit.GloebitMoneyModule
          *    Add this TransactionType to processAssetEnactHold(), processAssetConsumeHold(), processAssetCancelHold()
          *    to handle the particulars of asset delivery for this TransactionType
          *    These will be triggered by Gloebit during processing of this transaction
-         * 7. Implement any platform specific functional requirements of transacton process stages not handled in 
+         * 7. Implement any platform specific functional requirements of transaction process stages not handled in 
          *    asset enact/consume/cancel via the GloebitAPIWrapper ITransactionAlert interface AlertTransaction functions
          * 8. Provide messaging to user throughout transaction (see region GMM User Messaging)
          *    Add this TransactionType to alertUsersTransactionBegun()
@@ -1385,17 +1385,17 @@ namespace Gloebit.GloebitMoneyModule
         /// --- used for tracking/reporting/analysis
         /// </summary>
         /// <param name="transactionID">UUID to use for this transaction.  If UUID.Zero, a random UUID is chosen.</param>
-        /// <param name="transactionType">enum from OpenSim defining the type of transaction (buy object, pay object, pay user, object pays user, etc).  This will not affect how Gloebit process the monetary component of a transaction, but is useful for easily varying how OpenSim should handle processing once funds are transfered.</param>
+        /// <param name="transactionType">enum from OpenSim defining the type of transaction (buy object, pay object, pay user, object pays user, etc).  This will not affect how Gloebit process the monetary component of a transaction, but is useful for easily varying how OpenSim should handle processing once funds are transferred.</param>
         /// <param name="payerID">OpenSim UUID of agent sending gloebits.</param>
         /// <param name="payeeID">OpenSim UUID of agent receiving gloebits.  UUID.Zero if this is a fee being paid to the app owner (not a u2u txn).</param>
         /// <param name="amount">Amount of gloebits being transferred.</param>
         /// <param name="subscriptionID">UUID of subscription for automated transactions (Object pays user).  Otherwise UUID.Zero.</param>
-        /// <param name="partID">UUID of the object, when transaciton involves an object.  UUID.Zero otherwise.</param>
-        /// <param name="partName">string name of the object, when transaciton involves an object.  null otherwise.</param>
-        /// <param name="partDescription">string description of the object, when transaciton involves an object.  String.Empty otherwise.</param>
+        /// <param name="partID">UUID of the object, when transaction involves an object.  UUID.Zero otherwise.</param>
+        /// <param name="partName">string name of the object, when transaction involves an object.  null otherwise.</param>
+        /// <param name="partDescription">string description of the object, when transaction involves an object.  String.Empty otherwise.</param>
         /// <param name="categoryID">UUID of folder in object used when transactionType is ObjectBuy and saleType is copy.  UUID.Zero otherwise.  Required by IBuySellModule.</param>
         /// <param name="localID">uint region specific id of object used when transactionType is ObjectBuy.  0 otherwise.  Required by IBuySellModule.</param>
-        /// <param name="saleType">int differentiating between orginal, copy or contents for ObjectBuy.  Required by IBuySellModule to process delivery.</param>
+        /// <param name="saleType">int differentiating between original, copy or contents for ObjectBuy.  Required by IBuySellModule to process delivery.</param>
         /// <returns>GloebitTransaction created. if successful.</returns>
         private GloebitTransaction buildTransaction(UUID transactionID, TransactionType transactionType, UUID payerID, UUID payeeID, int amount, UUID subscriptionID, UUID partID, string partName, string partDescription, UUID categoryID, uint localID, int saleType)
         {
@@ -1481,7 +1481,7 @@ namespace Gloebit.GloebitMoneyModule
                     break;
             }
             
-            // Storing a null field in pgsql fails, so ensure partName and partDescription are not null incase those are not properly set to String.Empty when blank
+            // Storing a null field in pgsql fails, so ensure partName and partDescription are not null in case those are not properly set to String.Empty when blank
             if (partName == null) {
                 partName = String.Empty;
             }
@@ -1506,7 +1506,7 @@ namespace Gloebit.GloebitMoneyModule
         /// <summary>
         /// Helper function to build the minimal OpenSim transaction description sent to the Gloebit transactU2U endpoint.
         /// Used for tracking as well as information provided in transaction histories.
-        /// If transaction includes an object, use the version which takes a fourth paramater as a SceneObjectPart.
+        /// If transaction includes an object, use the version which takes a fourth parameter as a SceneObjectPart.
         /// </summary>
         /// <param name="regionname">Name of the OpenSim region where this transaction is taking place.</param>
         /// <param name="regionID">OpenSim UUID of the region where this transaction is taking place.</param>
@@ -1536,7 +1536,7 @@ namespace Gloebit.GloebitMoneyModule
         /// Helper function to build the minimal OpenSim transaction description including a ScenObjectPart
         /// sent to the Gloebit transactU2U endpoint.
         /// Used for tracking as well as information provided in transaction histories.
-        /// If transaction does not include an object, use the version which takes three paramaters instead.
+        /// If transaction does not include an object, use the version which takes three parameters instead.
         /// </summary>
         /// <param name="regionname">Name of the OpenSim region where this transaction is taking place.</param>
         /// <param name="regionID">OpenSim UUID of the region where this transaction is taking place.</param>
@@ -1565,7 +1565,7 @@ namespace Gloebit.GloebitMoneyModule
         /// Helper function to build the minimal OpenSim transaction description including LandData
         /// sent to the Gloebit transactU2U endpoint.
         /// Used for tracking as well as information provided in transaction histories.
-        /// If transaction does not include Parcel.LandData, use the version which takes three paramaters instead.
+        /// If transaction does not include Parcel.LandData, use the version which takes three parameters instead.
         /// </summary>
         /// <param name="regionname">Name of the OpenSim region where this transaction is taking place.</param>
         /// <param name="regionID">OpenSim UUID of the region where this transaction is taking place.</param>
@@ -1770,7 +1770,7 @@ namespace Gloebit.GloebitMoneyModule
 
         // This is called even if the the local asset had not previously been successfully enacted so cleanup can occur.
         // But txn.enacted should be checked before attempting to roll back anything done in enactHold
-        // It may not be possible for this to be called with txn.enacted=true since the local asset is the final transaction coponent
+        // It may not be possible for this to be called with txn.enacted=true since the local asset is the final transaction component
         // and the transaction should not be able to fail once it enacts successfully.
         public bool processAssetCancelHold(GloebitTransaction txn, out string returnMsg)
         {
@@ -1937,7 +1937,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="user">GloebitUser we are sending the URL to</param>
         /// <param name="subAuthID">ID of the authorization request the user will be asked to approve - provided by Gloebit.</param>
-        /// <param name="sub">GloebitSubscription which containes necessary details for message to user.</param>
+        /// <param name="sub">GloebitSubscription which contains necessary details for message to user.</param>
         /// <param name="isDeclined">Bool is true if this sub auth has already been declined by the user which should present different messaging.</param>
         public void LoadSubscriptionAuthorizationUriForUser(GloebitUser user, Uri subAuthUri, GloebitSubscription sub, bool isDeclined)
         {
@@ -1965,7 +1965,7 @@ namespace Gloebit.GloebitMoneyModule
         // <summary>
         // Helper property for retrieving the base URI for HTTP callbacks from Gloebit Service back into GMM
         // Used throughout the GMM to provide the callback URI to Gloebit or provide URLs to the user.
-        // The callbacks registered below should be avaialble at this base URI.
+        // The callbacks registered below should be available at this base URI.
         //</summary>
         private Uri BaseURI {
             get {
@@ -2410,7 +2410,7 @@ namespace Gloebit.GloebitMoneyModule
                 }
 
                 // Request balance from Gloebit.  Request Auth if not authed.  If Authed, always deliver Gloebit purchase url.
-                // NOTE: we are not passing the TransactionID to SendMoneyBalance as it appears ot always be UUID.Zero.
+                // NOTE: we are not passing the TransactionID to SendMoneyBalance as it appears to always be UUID.Zero.
                 UpdateBalance(agentID, client, -1);
             }
             else
@@ -2582,7 +2582,7 @@ namespace Gloebit.GloebitMoneyModule
                 return;
             }
 
-            // Check that the IBuySellModule is accesible before submitting the transaction to Gloebit
+            // Check that the IBuySellModule is accessible before submitting the transaction to Gloebit
             IBuySellModule module = s.RequestModuleInterface<IBuySellModule>();
             if (module == null) {
                 m_log.ErrorFormat("[GLOEBITMONEYMODULE] ObjectBuy FAILED to access to IBuySellModule");
@@ -2642,7 +2642,7 @@ namespace Gloebit.GloebitMoneyModule
                 return false;
             }
 
-            // Retrieve BuySellModule used for dilivering this asset
+            // Retrieve BuySellModule used for delivering this asset
             Scene s = LocateSceneClientIn(buyerClient.AgentId);
             // TODO: we should be locating the scene the part is in instead of the agent in case the agent moved (to a non Gloebit region) -- maybe store scene ID in asset -- see processLandBuy?
             IBuySellModule module = s.RequestModuleInterface<IBuySellModule>();
@@ -2759,7 +2759,7 @@ namespace Gloebit.GloebitMoneyModule
                 payerID: agentID, payeeID: parcel.LandData.OwnerID, amount: price, subscriptionID: UUID.Zero,
                 partID: parcel.LandData.GlobalID, partName: parcel.LandData.Name, partDescription: parcel.LandData.Description,
                 categoryID: regionID, localID: (uint)parcel.LandData.LocalID, saleType: 0);
-            // NOTE: using category & localID to retrieve parcel on callback incase GlobalID doesn't work.
+            // NOTE: using category & localID to retrieve parcel on callback in case GlobalID doesn't work.
             // Should consider storing all LandData in assetMap to ensure PassHours hasn't changed.
 
             if (txn == null) {
@@ -2912,7 +2912,7 @@ namespace Gloebit.GloebitMoneyModule
         // --- sets agentID, groupID, final, groupOwned, removeContribution, parcelLocalID, parcelArea, and parcelPrice to the packet data and authenticated to false.
         // ------ authenticated should probably be true since this is what the IClientAPI does, but it is set to false and ignored.
         // --- Calls all registered OnParcelBuy events, one (and maybe the only) of which is the Scene's ProcessParcelBuy function.
-        // Scene's ProcessParcelBuy func in Scene.PacketHandlers.cs
+        // Scene's ProcessParcelBuy function in Scene.PacketHandlers.cs
         // This function creates the LandBuyArgs and then calls two EventManager functions in succession:
         // --- TriggerValidateLandBuy: Calls all registered OnValidateLandBuy functions.  These are expected to set some variables, run some checks, and set the landValidated and economyValidated bools.
         // --- TriggerLandBuy: Calls all registered OnLandBuy functions which check the land/economyValidated bools.  If both are true, they proceed and process the land purchase.
@@ -3046,7 +3046,7 @@ namespace Gloebit.GloebitMoneyModule
                         m_landAssetMap[txn.TransactionID] = new Object[2]{s.RegionInfo.originRegionID, e};
                     }
                     bool submission_result = m_apiW.SubmitTransaction(txn, description, descMap, true);
-                    // See GloebitAPIWrapper.TransactU2UCompleted and helper messaging funcs for error messaging on failure - no action required.
+                    // See GloebitAPIWrapper.TransactU2UCompleted and helper messaging functions for error messaging on failure - no action required.
                     // See ProcessAssetEnactHold for proceeding with txn on success.
                     
                     if (!submission_result) {
@@ -3202,7 +3202,7 @@ namespace Gloebit.GloebitMoneyModule
          *   at the sim.  The GMM provides this helper-uri and the currency symbol via the OpenSim Extras.
          *   Some viewers (Firestorm & Alchemy at time of writing) consume these so this requires no
          *   configuration to work for a user on a Gloebit enabled region.  For users with other or older viewers,
-         *   the helper-uri will have to be conifgured properly, and if not pointed at a Gloebit enabled sim,
+         *   the helper-uri will have to be configured properly, and if not pointed at a Gloebit enabled sim,
          *   the grid will have to handle these calls, which it has traditionally done with an XMLRPC server and
          *   currency.php and landtool.php helper scripts.  That is rather complex, so we recommend that all 
          *   viewers adopt this patch and that grids request that their users update to a viewer with this patch.
@@ -3420,7 +3420,7 @@ namespace Gloebit.GloebitMoneyModule
         }
 
         /// <summary>
-        /// Deliver intro messaging for user in new session or new enviromnet.
+        /// Deliver intro messaging for user in new session or new environment.
         /// --- "Welcome to area running Gloebit in Sandbox for app MYAPP"
         /// Also sends auth message since we can't yet reliably tie into insufficient funds flow.
         /// </summary>
@@ -3480,13 +3480,13 @@ namespace Gloebit.GloebitMoneyModule
         /// <summary>
         /// Builds a status string and sends it to the client
         /// Always includes an intro with shortened txn id and a base message.
-        /// May include addtional transaction details and txn id based upon bool arguments and bool overrides.
+        /// May include additional transaction details and txn id based upon bool arguments and bool overrides.
         /// </summary>
         /// <param name="txn">GloebitTransaction this status is in regards to.</param>
         /// <param name="client">Client we are messaging.  If null, our sendMessage func will handle properly.</param>
         /// <param name="baseStatus">String Status message to deliver.</param>
-        /// <param name="showTxnDetails">If true, include txn details in status (can be overriden by global overrides).</param>
-        /// <param name="showTxnID">If true, include full transaction id in status (can be overriden by global overrides).</param>
+        /// <param name="showTxnDetails">If true, include txn details in status (can be overridden by global overrides).</param>
+        /// <param name="showTxnID">If true, include full transaction id in status (can be overridden by global overrides).</param>
         /// <param name="agentID">UUID of user we are messaging.  Only used if user is offline and client is null.</param>
         private void sendTxnStatusToClient(GloebitTransaction txn, IClientAPI client, string baseStatus, bool showTxnDetails, bool showTxnID, UUID agentID)
         {
@@ -3590,7 +3590,7 @@ namespace Gloebit.GloebitMoneyModule
         private void alertUsersTransactionPreparationFailure(TransactionType typeID, TransactionPrecheckFailure failure, IClientAPI payerClient)
         {
             // TODO: move these to a string resource at some point.
-            // Set up instruction strings which are used mutliple times
+            // Set up instruction strings which are used multiple times
             string tryAgainRelog = "Please retry your purchase.  If you continue to get this error, relog.";
             string tryAgainContactOwner = String.Format("Please try again.  If problem persists, contact {0}.", m_contactOwner);
             string tryAgainContactGloebit = String.Format("Please try again.  If problem persists, contact {0}.", m_contactGloebit);
@@ -3690,7 +3690,7 @@ namespace Gloebit.GloebitMoneyModule
             // Handle some failures that could happen from any transaction type
             switch (failure) {
                 case TransactionPrecheckFailure.EXISTING_TRANSACTION_ID:
-                    precheckFailure = "Transaction conflicted with existing transacion record with identical ID.";
+                    precheckFailure = "Transaction conflicted with existing transaction record with identical ID.";
                     instruction = tryAgainRelog;
                     break;
             }
@@ -3704,7 +3704,7 @@ namespace Gloebit.GloebitMoneyModule
             
             // send failure message to client
             // For now, only alert payer for simplicity and since We should only ever get here from an ObjectBuy
-            // TODO: replace UUID.Zero with the agentID of the payer once we add it to funciton args. -- not vital that these make it to offline user.
+            // TODO: replace UUID.Zero with the agentID of the payer once we add it to function args. -- not vital that these make it to offline user.
             sendMessageToClient(payerClient, failureMsg, UUID.Zero);
 
         }
@@ -3746,7 +3746,7 @@ namespace Gloebit.GloebitMoneyModule
                             break;
                         default:
                             // Should not get here as this should fail before transaction is built.
-                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] Transaction Begun With Unrecognized saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", txn.SaleType);
+                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] Transaction Begun With Unrecognised saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", txn.SaleType);
                             // TODO: Assert this.
                             //assert(txn.TransactionType >= 1 && txn.TransactionType <= 3);
                             break;
@@ -3821,7 +3821,7 @@ namespace Gloebit.GloebitMoneyModule
         /// Stages:
         /// --- Submitted: TransactU2U call succeeded
         /// --- Queued: TransactU2U async callback succeeded
-        ///             This will also trigger final success or failure if the transactoin did not include an asset with callback urls.
+        ///             This will also trigger final success or failure if the transaction did not include an asset with callback urls.
         ///             --- currently, this is txn == null which doesn't happen in OpenSim and will eventually switch to using an "asset".
         /// --- Enacted:
         /// ------ Funds transferred: AssetEnact started (all Gloebit components of transaction enacted successfully)
@@ -3860,7 +3860,7 @@ namespace Gloebit.GloebitMoneyModule
                     status = "Successfully submitted to Gloebit service.";
                     break;
                 case GloebitAPI.TransactionStage.QUEUE:
-                    // a) queued and gloebits transfered.
+                    // a) queued and gloebits transferred.
                     // b) resubmitted
                     // c) queued, but early enact failure
                     status = "Successfully received by Gloebit and queued for processing.";
@@ -3945,10 +3945,10 @@ namespace Gloebit.GloebitMoneyModule
                     status = "Successfully finalized local components of transaction.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_GLOEBIT:
-                    status = "Successfully canceled and rolled back transfer of gloebits.";
+                    status = "Successfully cancelled and rolled back transfer of gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_ASSET:
-                    status = "Successfully canceled and rolled back local components of transaction.";
+                    status = "Successfully cancelled and rolled back local components of transaction.";
                     break;
                 default:
                     m_log.ErrorFormat("[GLOEBITMONEYMODULE] alertUsersTransactionStageCompleted called on unhandled transaction stage : {0}", stage);
@@ -3966,7 +3966,7 @@ namespace Gloebit.GloebitMoneyModule
                 status = String.Format("{0}\n{1}", status, additionalDetails);
             }
             
-            // for now, we're only giong to send these to the payer.
+            // for now, we're only going to send these to the payer.
             IClientAPI payerClient = LocateClientObject(txn.PayerID);
             sendTxnStatusToClient(txn, payerClient, status, showDetailsWithTxnStage, showIDWithTxnStage);
         }
@@ -3987,7 +3987,7 @@ namespace Gloebit.GloebitMoneyModule
             // TODO: how does this work with instructions?
             
             // TODO: move these to a string resource at some point.
-            // Set up instruction strings which are used mutliple times
+            // Set up instruction strings which are used multiple times
             string tryAgainContactOwner = String.Format("Please try again.  If problem persists, contact {0}.", m_contactOwner);
             string tryAgainContactGloebit = String.Format("Please try again.  If problem persists, contact {0}.", m_contactGloebit);
             string subAuthDialogComing = "You will be presented with an additional message instructing you how to approve or deny authorization for future automated transactions for this subscription.";
@@ -4007,7 +4007,7 @@ namespace Gloebit.GloebitMoneyModule
             // Retrieve failure strings into temp variables based on transaction type and failure
             switch (stage) {
                 case GloebitAPI.TransactionStage.SUBMIT:
-                    error = "Region failed to propery create and send request to Gloebit.";
+                    error = "Region failed to properly create and send request to Gloebit.";
                     instruction = payeeInstruction = tryAgainContactOwner;
                     break;
                 case GloebitAPI.TransactionStage.AUTHENTICATE:
@@ -4045,7 +4045,7 @@ namespace Gloebit.GloebitMoneyModule
                             break;
                         case GloebitAPI.TransactionFailure.SUBSCRIPTION_AUTH_DECLINED:
                             error = "Payer has declined authorization for this subscription.";
-                            instruction = "You can review and alter your respsonse subscription authorization requests from the Subscriptions section of the Gloebit website.";
+                            instruction = "You can review and alter your response subscription authorization requests from the Subscriptions section of the Gloebit website.";
                             payeeInstruction = contactPayer;
                             break;
                         // Validate Payer
@@ -4068,11 +4068,11 @@ namespace Gloebit.GloebitMoneyModule
                             // message payer and payee
                             // TODO: Is it a privacy issue to alert buyer here?
                             // TODO: research if/when account is in this state.  Only by admin?  All accounts until merchants?
-                            error = "Payee's Gloebit account is unable to receive gloebits.";
+                            error = "Payee's Gloebit account is unable to receive Gloebits.";
                             instruction = contactPayee;
                             payeeInstruction = String.Format("Please contact {0} to address this issue", m_contactGloebit);
                             messagePayee = true;
-                            payeeMessage = String.Format("Gloebit:\nAttempt to pay you failed because your Gloebit account cannot receive gloebits.\n\n{0}", payeeInstruction);
+                            payeeMessage = String.Format("Gloebit:\nAttempt to pay you failed because your Gloebit account cannot receive Gloebits.\n\n{0}", payeeInstruction);
                             break;
                         default:
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE] alertUsersTransactionFailed called on unhandled validation failure : {0}", failure);
@@ -4088,11 +4088,11 @@ namespace Gloebit.GloebitMoneyModule
                     break;
                 case GloebitAPI.TransactionStage.ENACT_GLOEBIT:
                     // We get these through early-enact failures via GloebitAPIWrapper.transactU2UCompleted call -> AlertTransactionFailed
-                    error = "Transfer of gloebits failed.";
+                    error = "Transfer of Gloebits failed.";
                     switch (failure) {
                         case GloebitAPI.TransactionFailure.INSUFFICIENT_FUNDS:
                             error = String.Format("{0}  Insufficient funds.", error);
-                            instruction = "Go to https://www.gloebit.com/purchase to get more gloebits.";
+                            instruction = "Go to https://www.gloebit.com/purchase to get more Gloebits.";
                             payeeInstruction = contactPayer;    // not considering privacy issue since caused by auto-debit and payer would want to know of failure.
                             break;
                         default:

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -1941,6 +1941,10 @@ namespace Gloebit.GloebitMoneyModule
             IClientAPI client = LocateClientObject(UUID.Parse(user.PrincipalID));
             string title = "AUTHORIZE GLOEBIT";
             string body = "To use Gloebit currency, please authorize Gloebit to link to your avatar's account on this web page:";
+			
+			// Some find these popups annoying especially if they don't want to use Gloebit on their region so we just don't send them popups
+			// Gloebit is still enabled and users who already authed themselves can use it, but it won't nag anyone to register
+			// A forever dismiss until the balance is clicked again would work better, but is a lot harder to implement
 			if (sendpopups)
 				SendUrlToClient(client, title, body, authorizeUri);
         }

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -3468,8 +3468,9 @@ namespace Gloebit.GloebitMoneyModule
             }
             Thread welcomeMessageThread = new Thread(delegate() {
                 Thread.Sleep(delay * 1000);  // Delay milliseconds
-                // Deliver welcome message
-                sendMessageToClient(client, msg, client.AgentId);
+                // Deliver welcome message if we have popups enabled
+				if (sendpopups)
+					sendMessageToClient(client, msg, client.AgentId);
                 // If authed, delivery url where user can purchase Gloebits
                 if (user.IsAuthed()) {
                     if (m_showNewSessionPurchaseIM) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -459,7 +459,7 @@ namespace Gloebit.GloebitMoneyModule
                     default:
                         m_environment = GLBEnv.None;
                         m_apiUrl = null;
-                        m_log.WarnFormat("[GLOEBITMONEYMODULE] GLBEnvironment \"{0}\" unrecognized, setting to None", envString); 
+                        m_log.WarnFormat("[GLOEBITMONEYMODULE] GLBEnvironment \"{0}\" unrecognised, setting to None", envString); 
                         break;
                 }
                 m_keyAlias = config.GetString("GLBKeyAlias", null);
@@ -511,7 +511,7 @@ namespace Gloebit.GloebitMoneyModule
         }
         
         /// <summary>
-        /// Helper funciton to store grid info regardless of whether the source is local (Standalone) or remote (Rubust).
+        /// Helper function to store grid info regardless of whether the source is local (Standalone) or remote (Rubust).
         /// Stores gridName, gridNick, and economy config values
         /// </summary>
         /// <param name="gridName">Name of the Grid this sim process is connecting to.</param>
@@ -564,7 +564,7 @@ namespace Gloebit.GloebitMoneyModule
                          * The GMM provides this helper-uri and the currency symbol via the OpenSim Extras.  
                          * Some viewers (Firestorm & Alchemy at time of writing) consume these so this requires no
                          * configuration to work for a user on a Gloebit enabled region.  For users with other or older viewers,
-                         * the helper-uri will have to be conifgured properly, and if not pointed at a Gloebit enabled sim,
+                         * the helper-uri will have to be configured properly, and if not pointed at a Gloebit enabled sim,
                          * the grid will have to handle these calls, which it has traditionally done with an XMLRPC server and
                          * currency.php and landtool.php helper scripts.  That is rather complex, so we recommend that all 
                          * viewers adopt this patch and that grids request that their users update to a viewer with this patch.
@@ -1258,7 +1258,7 @@ namespace Gloebit.GloebitMoneyModule
         ///                 0: never deliver
         ///                 positive number: deliver if user's balance is below this indicator
         /// </param>
-        /// <returns>Gloebit balance for the gloebit account linked to this OpenSim agent or 0.0.</returns>
+        /// <returns>Gloebit balance for the Gloebit account linked to this OpenSim agent or 0.0.</returns>
         private double UpdateBalance(UUID agentID, IClientAPI client, int purchaseIndicator)
         {
             int returnfunds = 0;
@@ -1298,7 +1298,7 @@ namespace Gloebit.GloebitMoneyModule
                 if (u.IsAuthed()) {
                     // Deliver Purchase URI in case the helper-uri is not working
                     Uri url = m_apiW.BuildPurchaseURI(BaseURI, u);
-                    SendUrlToClient(client, "Need more gloebits?", "Buy gloebits you can spend on this grid:", url);
+                    SendUrlToClient(client, "Need more Gloebits?", "Buy Gloebits you can spend on this grid:", url);
                 }
             }
             return realBal;
@@ -1367,7 +1367,7 @@ namespace Gloebit.GloebitMoneyModule
             USER_PAYS_OBJECT    = 5008,             // comes through OnMoneyTransfer
 
             /* Auto-Debit Subscription */
-            OBJECT_PAYS_USER    = 5009,             // script auto debit owner - comes thorugh ObjectGiveMoney
+            OBJECT_PAYS_USER    = 5009,             // script auto debit owner - comes through ObjectGiveMoney
 
             /* Catch-all for unimplemented MoveMoney types */
             MOVE_MONEY_GENERAL  = 5011,             // Unimplemented MoveMoney - will fail.
@@ -1399,9 +1399,9 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="transactionID">UUID to use for this transaction.  If UUID.Zero, a random UUID is chosen.</param>
         /// <param name="transactionType">enum from OpenSim defining the type of transaction (buy object, pay object, pay user, object pays user, etc).  This will not affect how Gloebit process the monetary component of a transaction, but is useful for easily varying how OpenSim should handle processing once funds are transferred.</param>
-        /// <param name="payerID">OpenSim UUID of agent sending gloebits.</param>
-        /// <param name="payeeID">OpenSim UUID of agent receiving gloebits.  UUID.Zero if this is a fee being paid to the app owner (not a u2u txn).</param>
-        /// <param name="amount">Amount of gloebits being transferred.</param>
+        /// <param name="payerID">OpenSim UUID of agent sending Gloebits.</param>
+        /// <param name="payeeID">OpenSim UUID of agent receiving Gloebits.  UUID.Zero if this is a fee being paid to the app owner (not a u2u txn).</param>
+        /// <param name="amount">Amount of Gloebits being transferred.</param>
         /// <param name="subscriptionID">UUID of subscription for automated transactions (Object pays user).  Otherwise UUID.Zero.</param>
         /// <param name="partID">UUID of the object, when transaction involves an object.  UUID.Zero otherwise.</param>
         /// <param name="partName">string name of the object, when transaction involves an object.  null otherwise.</param>
@@ -1523,7 +1523,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="regionname">Name of the OpenSim region where this transaction is taking place.</param>
         /// <param name="regionID">OpenSim UUID of the region where this transaction is taking place.</param>
-        /// <param name="txnType">String describing the type of transaction.  eg. ObjectBuy, PayObject, PayUser, etc.</param>
+        /// <param name="txnType">String describing the type of transaction.  e.g. ObjectBuy, PayObject, PayUser, etc.</param>
         /// <returns>OSDMap to be sent with the transaction request parameters.  Map contains six dictionary entries, each including an OSDArray.</returns>
         private OSDMap buildOpenSimTransactionDescMap(string regionname, string regionID, string txnType)
         {
@@ -1582,7 +1582,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="regionname">Name of the OpenSim region where this transaction is taking place.</param>
         /// <param name="regionID">OpenSim UUID of the region where this transaction is taking place.</param>
-        /// <param name="txnType">String describing the type of transaction.  eg. ObjectBuy, PayObject, PayUser, etc.</param>
+        /// <param name="txnType">String describing the type of transaction.  e.g. ObjectBuy, PayObject, PayUser, etc.</param>
         /// <param name="pld">Object (as Parcel.LandData) which is involved in this transaction (pass being purchased for it).</param>
         /// <returns>OSDMap to be sent with the transaction request parameters.  Map contains six dictionary entries, each including an OSDArray.</returns>
         private OSDMap buildOpenSimTransactionDescMap(string regionname, string regionID, string txnType, LandData pld)
@@ -1622,9 +1622,9 @@ namespace Gloebit.GloebitMoneyModule
 
         /* Interface for handling state progression of assets.
          * Any transaction which includes a local asset will receive callbacks at each transaction stage.
-         * ENACT -> Funds have been transfered.  Process local asset (generally deliver a product)
+         * ENACT -> Funds have been transferred.  Process local asset (generally deliver a product)
          * CONSUME -> Funds have been released to recipient.  Finalize anything necessary.
-         * CANCEL -> Transaction has been canceled.  Undo anything necessary
+         * CANCEL -> Transaction has been cancelled.  Undo anything necessary
          */
 
         public bool processAssetEnactHold(GloebitTransaction txn, out string returnMsg) {
@@ -1726,7 +1726,7 @@ namespace Gloebit.GloebitMoneyModule
             m_log.InfoFormat("[GLOEBITMONEYMODULE].processAssetConsumeHold SUCCESS - transaction complete");
 
             // If we've gotten this call, then the Gloebit components have enacted successfully
-            // all transferred funds have been commited.
+            // all transferred funds have been committed.
             // ITransactionAlert.AlertTransactionStageCompleted for CONSUME_GLOEBIT just fired
 
             switch ((TransactionType)txn.TransactionType) {
@@ -2058,7 +2058,7 @@ namespace Gloebit.GloebitMoneyModule
 
                 // Deliver Purchase URI in case the helper-uri is not working
                 Uri url = m_apiW.BuildPurchaseURI (BaseURI, user);
-                SendUrlToClient (client, "Gloebit Authorization Successful", "Buy gloebits you can spend on this grid:", url);
+                SendUrlToClient (client, "Gloebit Authorization Successful", "Buy Gloebits you can spend on this grid:", url);
             }
         }
 
@@ -2343,7 +2343,7 @@ namespace Gloebit.GloebitMoneyModule
                     UpdateBalance(client.AgentId, client, 0);
                 } else {
                     //update viewer balance to zero in case user came from alt money module region and has old viewer
-                    //Note: New firestorm viewer will request update and will get double send here.
+                    //Note: New Firestorm viewer will request update and will get double send here.
                     int zeroBal = 0;
                     client.SendMoneyBalance(UUID.Zero, true, new byte[0], zeroBal, 0, UUID.Zero, false, UUID.Zero, false, 0, String.Empty);
                 }
@@ -2587,7 +2587,7 @@ namespace Gloebit.GloebitMoneyModule
             // Validate that is the client sent the proper sale type the object has set
             if (saleType < 1 || saleType > 3) {
                 // Should not get here unless an object purchase is submitted with a bad or new (but unimplemented) saleType.
-                m_log.ErrorFormat("[GLOEBITMONEYMODULE] ObjectBuy Unrecognized saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", saleType);
+                m_log.ErrorFormat("[GLOEBITMONEYMODULE] ObjectBuy Unrecognised saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", saleType);
                 alertUsersTransactionPreparationFailure(TransactionType.USER_BUYS_OBJECT, TransactionPrecheckFailure.SALE_TYPE_INVALID, remoteClient);
                 return;
             }
@@ -2732,7 +2732,7 @@ namespace Gloebit.GloebitMoneyModule
             // TODO: Message user
             //    return;
             //}
-            // We can't handle group transacitons, so fail that
+            // We can't handle group transactions, so fail that
             if(parcel.LandData.IsGroupOwned)
             {
                 m_log.WarnFormat("[GLOEBITMONEYMODULE] AgentID:{0} attempted to buy a pass on parcel:{1} which is group owned.  Group Transactions are not defined.", agentID, parcel.LandData.GlobalID);
@@ -3188,7 +3188,7 @@ namespace Gloebit.GloebitMoneyModule
                     return;
                 }
 
-                // Add this user to map of waiting for sub to creat auth.
+                // Add this user to map of waiting for sub to create auth.
                 lock(m_authWaitingForSubMap) {
                     m_authWaitingForSubMap[objectID] = client;
                 }
@@ -3462,14 +3462,14 @@ namespace Gloebit.GloebitMoneyModule
                 delay = 10; // Delay 10 seconds if viewer isn't fully loaded, shows up as offline while away
             }
             Thread welcomeMessageThread = new Thread(delegate() {
-                Thread.Sleep(delay * 1000);  // Delay miliseconds
+                Thread.Sleep(delay * 1000);  // Delay milliseconds
                 // Deliver welcome message
                 sendMessageToClient(client, msg, client.AgentId);
                 // If authed, delivery url where user can purchase gloebits
                 if (user.IsAuthed()) {
                     if (m_showNewSessionPurchaseIM) {
                         Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);
-                        SendUrlToClient(client, "How to purchase gloebits:", "Buy gloebits you can spend in this area:", url);
+                        SendUrlToClient(client, "How to purchase Gloebits:", "Buy Gloebits you can spend in this area:", url);
                     }
                 } else {
                     if (m_showNewSessionAuthIM) {
@@ -3548,7 +3548,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="payerID">UUID of payer from transaction that triggered this alert.</param>
         /// <param name="payeeID">UUID of payee from transaction that triggered this alert.</param>
-        /// <param name="amount">Int amount of gloebits from transaction that triggered this alert.</param>
+        /// <param name="amount">Int amount of Gloebits from transaction that triggered this alert.</param>
         /// <param name="subName">String name of subscription being sent to Gloebit for creation.</param>
         /// <param name="subDesc">String description of subscription being sent to Gloebit for creation.</param> 
         private void alertUsersSubscriptionTransactionFailedForSubscriptionCreation(UUID payerID, UUID payeeID, int amount, string subName, string subDesc)
@@ -3571,7 +3571,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="payerID">UUID of payer from transaction that triggered this alert.</param>
         /// <param name="payeeID">UUID of payee from transaction that triggered this alert.</param>
-        /// <param name="amount">Int amount of gloebits from transaction that triggered this alert.</param>
+        /// <param name="amount">Int amount of Gloebits from transaction that triggered this alert.</param>
         /// <param name="sub">GloebitSubscription that triggered this alert.</param>
         private void alertUsersSubscriptionTransactionFailedForGloebitAuthorization(UUID payerID, UUID payeeID, int amount, GloebitSubscription sub)
         {
@@ -3880,7 +3880,7 @@ namespace Gloebit.GloebitMoneyModule
                     status = "Successfully received by Gloebit and queued for processing.";
                     break;
                 case GloebitAPI.TransactionStage.ENACT_GLOEBIT:
-                    status = "Successfully transferred gloebits.";
+                    status = "Successfully transferred Gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.ENACT_ASSET:
                     switch ((TransactionType)txn.TransactionType) {
@@ -3953,13 +3953,13 @@ namespace Gloebit.GloebitMoneyModule
                     }
                     break;
                 case GloebitAPI.TransactionStage.CONSUME_GLOEBIT:
-                    status = "Successfully finalized transfer of gloebits.";
+                    status = "Successfully finalized transfer of Gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.CONSUME_ASSET:
                     status = "Successfully finalized local components of transaction.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_GLOEBIT:
-                    status = "Successfully cancelled and rolled back transfer of gloebits.";
+                    status = "Successfully cancelled and rolled back transfer of Gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_ASSET:
                     status = "Successfully cancelled and rolled back local components of transaction.";

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -134,6 +134,8 @@ namespace Gloebit.GloebitMoneyModule
         private bool m_enabled = true;
         // Set to false if anything is misconfigured
         private bool m_configured = true;
+		// Configure true if not present
+		private bool sendpopups = true;
         
         // Populated from Gloebit.ini
         private UUID[] m_enabledRegions = null;         // Regions on sim to individually enable GMM.
@@ -391,7 +393,7 @@ namespace Gloebit.GloebitMoneyModule
 				m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
 				
 				// Should we send popups to users or not, some find them annoying especially if they are not using the system
-				bool sendpopups = config.GetBoolean("SendPopups", true);
+				sendpopups = config.GetBoolean("SendPopups", true);
 				
 				if (sendpopups == false)
 				{
@@ -399,7 +401,6 @@ namespace Gloebit.GloebitMoneyModule
 				} else {
 					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
 				}
-				
 				
                 m_enabled = m_enabled && enabled;
                 if (!m_enabled) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -134,8 +134,6 @@ namespace Gloebit.GloebitMoneyModule
         private bool m_enabled = true;
         // Set to false if anything is misconfigured
         private bool m_configured = true;
-        // Configure true if not present
-        private bool m_showWelcomeMessage = true;
         
         // Populated from Gloebit.ini
         private UUID[] m_enabledRegions = null;         // Regions on sim to individually enable GMM.
@@ -151,6 +149,9 @@ namespace Gloebit.GloebitMoneyModule
         private bool m_disablePerSimCurrencyExtras = false;
         private bool m_showNewSessionPurchaseIM = false;
         private bool m_showNewSessionAuthIM = true;
+        private bool m_showWelcomeMessage = true;
+        private bool m_forceNewLandPassFlow = false;
+        private bool m_forceNewHTTPFlow = false;
         
         // Populated from grid info
         private string m_gridnick = "unknown_grid";
@@ -204,10 +205,6 @@ namespace Gloebit.GloebitMoneyModule
         private string m_opensimVersionNumber = String.Empty;
         private bool m_newLandPassFlow = false;
         private bool m_newHTTPFlow = false;
-        
-        // Allow overriding of versions in case version number can't be identified
-        private bool m_forceNewLandPassFlow = false;
-        private bool m_forceNewHTTPFlow = false;
 
 
         #region IRegionModuleBase Interface
@@ -547,6 +544,7 @@ namespace Gloebit.GloebitMoneyModule
             m_configured = false;
         }
 
+        // Helper funciton used in AddRegion for post 0.9.2.0 XML RPC Handlers 
         public void processPHP(IOSHttpRequest request, IOSHttpResponse response)
         {
             MainServer.Instance.HandleXmlRpcRequests((OSHttpRequest)request, (OSHttpResponse)response, m_rpcHandlers);

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -134,8 +134,8 @@ namespace Gloebit.GloebitMoneyModule
         private bool m_enabled = true;
         // Set to false if anything is misconfigured
         private bool m_configured = true;
-		// Configure true if not present
-		private bool m_showWelcomeMessage = true;
+        // Configure true if not present
+        private bool m_showWelcomeMessage = true;
         
         // Populated from Gloebit.ini
         private UUID[] m_enabledRegions = null;         // Regions on sim to individually enable GMM.
@@ -195,19 +195,19 @@ namespace Gloebit.GloebitMoneyModule
         
         // Store link to client we can't yet create auth for because there is no sub on file.  Handle in return from sub creation.
         private Dictionary<UUID, IClientAPI> m_authWaitingForSubMap = new Dictionary<UUID, IClientAPI>();
-		
-		// New dictionary to hold newer http handlers
-		private Dictionary<string, XmlRpcMethod> m_rpcHandlers;
+
+        // New dictionary to hold newer http handlers
+        private Dictionary<string, XmlRpcMethod> m_rpcHandlers;
         
         // Some internal storage to only retrieve info once
         private string m_opensimVersion = String.Empty;
         private string m_opensimVersionNumber = String.Empty;
         private bool m_newLandPassFlow = false;
-		private bool m_newHTTPFlow = false;
-		
-		// Allow overriding of versions in case version number can't be identified
-		private bool m_FnewLandPassFlow = false;
-		private bool m_FnewHTTPFlow = false;
+        private bool m_newHTTPFlow = false;
+        
+        // Allow overriding of versions in case version number can't be identified
+        private bool m_FnewLandPassFlow = false;
+        private bool m_FnewHTTPFlow = false;
 
 
         #region IRegionModuleBase Interface
@@ -397,24 +397,24 @@ namespace Gloebit.GloebitMoneyModule
                 /*** Get GloebitMoneyModule configuration details ***/
                 // Is Gloebit disabled, enabled across the entire sim process, or on certain regions?
                 bool enabled = config.GetBoolean("Enabled", false);
-				
-				m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
-				
-				// Should we send popups to users or not, some find them annoying especially if they are not using the system
-				m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
-				
-				if (m_showWelcomeMessage == false)
-				{
-					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send welcome message to users!");
-				} else {
-					m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
-				}
-				
-				// If version cannot be detected override workflow selection via config
-				// Currently not documented because last resort if all version checking fails
-				m_FnewLandPassFlow = config.GetBoolean("GLBNewLandPassFlow", false);
-				m_FnewHTTPFlow = config.GetBoolean("GLBNewHTTPFlow", false);
-				
+                
+                m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Enabled flag set to {0}.", enabled);
+
+                // Should we send popups to users or not, some find them annoying especially if they are not using the system
+                m_showWelcomeMessage = config.GetBoolean("GLBShowWelcomeMessage", true);
+
+                if (m_showWelcomeMessage == false)
+                {
+                    m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will not send welcome message to users!");
+                } else {
+                    m_log.InfoFormat("[GLOEBITMONEYMODULE] [Gloebit] Will inform users about Gloebit!");
+                }
+
+                // If version cannot be detected override workflow selection via config
+                // Currently not documented because last resort if all version checking fails
+                m_FnewLandPassFlow = config.GetBoolean("GLBNewLandPassFlow", false);
+                m_FnewHTTPFlow = config.GetBoolean("GLBNewHTTPFlow", false);
+
                 m_enabled = m_enabled && enabled;
                 if (!m_enabled) {
                     m_log.Info("[GLOEBITMONEYMODULE] Not enabled globally for sim. (to enable set \"Enabled = true\" in [Gloebit] and \"economymodule = Gloebit\" in [Economy])");
@@ -443,7 +443,7 @@ namespace Gloebit.GloebitMoneyModule
                 }
                 // Should we disable adding info to OpenSimExtras map
                 m_disablePerSimCurrencyExtras = config.GetBoolean("DisablePerSimCurrencyExtras", false);
-                // Should we send new session IMs informing user how to auth or purchase Gloebits
+                // Should we send new session IMs informing user how to auth or purchase gloebits
                 m_showNewSessionPurchaseIM = config.GetBoolean("GLBShowNewSessionPurchaseIM", false);
                 m_showNewSessionAuthIM = config.GetBoolean("GLBShowNewSessionAuthIM", true);
                 // Are we using custom db connection info
@@ -473,7 +473,7 @@ namespace Gloebit.GloebitMoneyModule
                     default:
                         m_environment = GLBEnv.None;
                         m_apiUrl = null;
-                        m_log.WarnFormat("[GLOEBITMONEYMODULE] GLBEnvironment \"{0}\" unrecognised, setting to None", envString); 
+                        m_log.WarnFormat("[GLOEBITMONEYMODULE] GLBEnvironment \"{0}\" unrecognized, setting to None", envString); 
                         break;
                 }
                 m_keyAlias = config.GetString("GLBKeyAlias", null);
@@ -552,11 +552,11 @@ namespace Gloebit.GloebitMoneyModule
             m_enabled = false;
             m_configured = false;
         }
-		
-		public void processPHP(IOSHttpRequest request, IOSHttpResponse response)
-		{
-			MainServer.Instance.HandleXmlRpcRequests((OSHttpRequest)request, (OSHttpResponse)response, m_rpcHandlers);
-		}
+
+        public void processPHP(IOSHttpRequest request, IOSHttpResponse response)
+        {
+            MainServer.Instance.HandleXmlRpcRequests((OSHttpRequest)request, (OSHttpResponse)response, m_rpcHandlers);
+        }
 
         public void AddRegion(Scene scene)
         {
@@ -595,27 +595,27 @@ namespace Gloebit.GloebitMoneyModule
 
                         // These functions can handle the calls to the economy helper-uri if it is configured to point at the sim.  
                         // They will enable land purchasing, buy-currency, and insufficient-funds flows.
-                        // *NOTE* Gloebits can not currently be purchased from a viewer, but this allows Gloebit to control the
+                        // *NOTE* gloebits can not currently be purchased from a viewer, but this allows Gloebit to control the
                         // messaging in this flow and send users to the Gloebit website for purchasing.
 
-						// Post version 0.9.2.0 the httpserver changed requiring different approach to the preflights
-						if (m_newHTTPFlow == true)
-						{
-							m_rpcHandlers = new Dictionary<string, XmlRpcMethod>();
-							m_rpcHandlers.Add("getCurrencyQuote", quote_func);
-							m_rpcHandlers.Add("buyCurrency", buy_func);
-							m_rpcHandlers.Add("preflightBuyLandPrep", preflightBuyLandPrep_func);
-							m_rpcHandlers.Add("buyLandPrep", landBuy_func);
-							MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/landtool.php", processPHP));
-							MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/currency.php", processPHP));
-						} else {
-							httpServer.AddXmlRPCHandler("getCurrencyQuote", quote_func);
-							httpServer.AddXmlRPCHandler("buyCurrency", buy_func);
-							httpServer.AddXmlRPCHandler("preflightBuyLandPrep", preflightBuyLandPrep_func);
-							httpServer.AddXmlRPCHandler("buyLandPrep", landBuy_func);
-						}
-						
-						/********** Register endpoints the Gloebit Service will call back into **********/
+                        // Post version 0.9.2.0 the httpserver changed requiring different approach to the preflights
+                        if (m_newHTTPFlow == true)
+                        {
+                            m_rpcHandlers = new Dictionary<string, XmlRpcMethod>();
+                            m_rpcHandlers.Add("getCurrencyQuote", quote_func);
+                            m_rpcHandlers.Add("buyCurrency", buy_func);
+                            m_rpcHandlers.Add("preflightBuyLandPrep", preflightBuyLandPrep_func);
+                            m_rpcHandlers.Add("buyLandPrep", landBuy_func);
+                            MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/landtool.php", processPHP));
+                            MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/currency.php", processPHP));
+                        } else {
+                            httpServer.AddXmlRPCHandler("getCurrencyQuote", quote_func);
+                            httpServer.AddXmlRPCHandler("buyCurrency", buy_func);
+                            httpServer.AddXmlRPCHandler("preflightBuyLandPrep", preflightBuyLandPrep_func);
+                            httpServer.AddXmlRPCHandler("buyLandPrep", landBuy_func);
+                        }
+
+                        /********** Register endpoints the Gloebit Service will call back into **********/
                         RegisterGloebitWebhooks(httpServer);
                     }
 
@@ -696,99 +696,99 @@ namespace Gloebit.GloebitMoneyModule
         #endregion // IRegionModuleBase Interface
         
         #region ISharedRegionModule Interface
-		
-		// TODO: Find a better method to do version testing, do not rely on version number, it can be edited easily and does not reflect code
+
+        // TODO: Find a better method to do version testing, do not rely on version number, it can be edited easily and does not reflect code
         public void PostInitialise()
         {
-			// Setting to large negative so if not found is not 0
-			int vn1 = -9999;
-			int vn2 = -9999;
-			int vn3 = -9999;
-			int vn4 = -9999;
-			string detectedOSVersion = "unknown";
+            // Setting to large negative so if not found is not 0
+            int vn1 = -9999;
+            int vn2 = -9999;
+            int vn3 = -9999;
+            int vn4 = -9999;
+            string detectedOSVersion = "unknown";
             m_opensimVersion = OpenSim.VersionInfo.Version;
             m_opensimVersionNumber = OpenSim.VersionInfo.VersionNumber;
             char[] delimiterChars = { '.' };
             string[] numbers = m_opensimVersionNumber.Split(delimiterChars, System.StringSplitOptions.RemoveEmptyEntries);
-			
-			// See if we can parse the string at all
-			try {
-				vn1 = int.Parse(numbers[0]);
-				vn2 = int.Parse(numbers[1]);
-				vn3 = int.Parse(numbers[2]);
-			} catch {
-				m_log.DebugFormat("[GLOEBITMONEYMODULE] Unable to parse version information, Gloebit cannot handle unofficial versions");
-			}
-			// Fourth number may not be present on all versions
-			try {
-					vn4 = int.Parse(numbers[3]);
-				}
-			catch {}
-			
-			// This is a really poor way of detecting versions, instead the capabilities of functions and httpserver should be tested directly to determine which workflows to use!!!		
+
+            // See if we can parse the string at all
+            try {
+                vn1 = int.Parse(numbers[0]);
+                vn2 = int.Parse(numbers[1]);
+                vn3 = int.Parse(numbers[2]);
+            } catch {
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] Unable to parse version information, Gloebit cannot handle unofficial versions");
+            }
+            // Fourth number may not be present on all versions
+            try {
+                vn4 = int.Parse(numbers[3]);
+            }
+            catch {}
+
+            // This is a really poor way of detecting versions, instead the capabilities of functions and httpserver should be tested directly to determine which workflows to use!!!		
             if ((vn1 > 0) || (vn2 > 9) || (vn2 == 9 && vn3 > 0)) 
-			{
+            {
                 // 0.9.1 and beyond are the new land pass flow.
                 // Note, there are some early versions of 0.9.1 before any release candidate which do not have the new
                 // flow, but we can't easily determine those and no one should be running those in production.
-				detectedOSVersion = "=>0.9.1";
+                detectedOSVersion = "=>0.9.1";
                 m_newLandPassFlow = true;
-				if ((vn2 == 9) && (vn3 == 2 || vn3 > 2) && (vn4 == 0 || vn4 > 0)) 
-				{
-					// Test for version 0.9.2.0 and beyond which contains changes to httpserver and thus needs different workflows also
-					detectedOSVersion = "=>0.9.2.0";
-					m_newLandPassFlow = true;
-					m_newHTTPFlow = true;
-				}
+                if ((vn2 == 9) && (vn3 == 2 || vn3 > 2) && (vn4 == 0 || vn4 > 0)) 
+                {
+                    // Test for version 0.9.2.0 and beyond which contains changes to httpserver and thus needs different workflows also
+                    detectedOSVersion = "=>0.9.2.0";
+                    m_newLandPassFlow = true;
+                    m_newHTTPFlow = true;
+                }
             }
-			else if (vn1 == 0 && vn2 == 9 && vn3 == 0)
-			{
+            else if (vn1 == 0 && vn2 == 9 && vn3 == 0)
+            {
                 // 0.9.0-release pulled in 0.9.1 changes and is new flow, but rest of 0.9.0 is not.
                 // assume dev on 0.9.0.1, 0.9.0.2 will be new flow
                 if (vn4 > 0)
-				{
+                {
                     // 0.9.0.1, 0.9.0.2, etc.
-					detectedOSVersion = "=>0.9.0.1";
+                    detectedOSVersion = "=>0.9.0.1";
                     m_newLandPassFlow = true;
                 }
-				else
-				{
+                else
+                {
                     // Need to pull version flavour and check it.
                     // TODO: may need to split on spaces or hyphens and then pull last field because flavour is not friggin public
                     char[] dChars = { '-', ' ' };
                     string[] versionParts = m_opensimVersion.Split(dChars, System.StringSplitOptions.RemoveEmptyEntries);
                     string flavour = versionParts[versionParts.Length - 1];     // TODO: do we every have to worry about this being length 0?
                     if (flavour == OpenSim.VersionInfo.Flavour.Release.ToString())
-					{
+                    {
                         // 0.9.0 release
-						detectedOSVersion = "=0.9.0";
+                        detectedOSVersion = "=0.9.0";
                         m_newLandPassFlow = true;
                     }
                 }
                 // TODO: Unclear if post-fixes is a necessary flavour check yet.
             }
-			else
-			{
-				// If all else fails version is unknown
-				detectedOSVersion = "unknown";
-				m_log.DebugFormat("[GLOEBITMONEYMODULE] Could not determine OpenSim version or unknown version, module may not function! Use config overrides!");		
-			}
-			
-			// If version is unknown or changed by user allow override via config	
-			if (m_FnewHTTPFlow == true)
-			{
-				m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new HTTP Flow, set by config");
-				m_newHTTPFlow = true;
-			}
-			
-			if (m_FnewLandPassFlow == true)
-			{
-				m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new LandPass Flow, set by config");
-				m_newLandPassFlow = true;
-			}			
-			
-			// Provide detailed feedback on which version is detected, for debugging and information
-			m_log.DebugFormat("[GLOEBITMONEYMODULE] OpenSim version {0} present, detected: {1} Using New LandPass Flow: {2} Using New HTTP Flow: {3}", m_opensimVersionNumber.ToString(), detectedOSVersion.ToString(), m_newLandPassFlow.ToString(), m_newHTTPFlow.ToString());
+            else
+            {
+                // If all else fails version is unknown
+                detectedOSVersion = "unknown";
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] Could not determine OpenSim version or unknown version, module may not function! Use config overrides!");		
+            }
+
+            // If version is unknown or changed by user allow override via config	
+            if (m_FnewHTTPFlow == true)
+            {
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new HTTP Flow, set by config");
+                m_newHTTPFlow = true;
+            }
+
+            if (m_FnewLandPassFlow == true)
+            {
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] Using new LandPass Flow, set by config");
+                m_newLandPassFlow = true;
+            }			
+
+            // Provide detailed feedback on which version is detected, for debugging and information
+            m_log.DebugFormat("[GLOEBITMONEYMODULE] OpenSim version {0} present, detected: {1} Using New LandPass Flow: {2} Using New HTTP Flow: {3}", m_opensimVersionNumber.ToString(), detectedOSVersion.ToString(), m_newLandPassFlow.ToString(), m_newHTTPFlow.ToString());
         }
         
         #endregion // ISharedRegionModule Interface
@@ -1388,7 +1388,7 @@ namespace Gloebit.GloebitMoneyModule
                 if (u.IsAuthed()) {
                     // Deliver Purchase URI in case the helper-uri is not working
                     Uri url = m_apiW.BuildPurchaseURI(BaseURI, u);
-                    SendUrlToClient(client, "Need more Gloebits?", "Buy Gloebits you can spend on this grid:", url);
+                    SendUrlToClient(client, "Need more gloebits?", "Buy gloebits you can spend on this grid:", url);
                 }
             }
             return realBal;
@@ -1489,9 +1489,9 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="transactionID">UUID to use for this transaction.  If UUID.Zero, a random UUID is chosen.</param>
         /// <param name="transactionType">enum from OpenSim defining the type of transaction (buy object, pay object, pay user, object pays user, etc).  This will not affect how Gloebit process the monetary component of a transaction, but is useful for easily varying how OpenSim should handle processing once funds are transferred.</param>
-        /// <param name="payerID">OpenSim UUID of agent sending Gloebits.</param>
-        /// <param name="payeeID">OpenSim UUID of agent receiving Gloebits.  UUID.Zero if this is a fee being paid to the app owner (not a u2u txn).</param>
-        /// <param name="amount">Amount of Gloebits being transferred.</param>
+        /// <param name="payerID">OpenSim UUID of agent sending gloebits.</param>
+        /// <param name="payeeID">OpenSim UUID of agent receiving gloebits.  UUID.Zero if this is a fee being paid to the app owner (not a u2u txn).</param>
+        /// <param name="amount">Amount of gloebits being transferred.</param>
         /// <param name="subscriptionID">UUID of subscription for automated transactions (Object pays user).  Otherwise UUID.Zero.</param>
         /// <param name="partID">UUID of the object, when transaction involves an object.  UUID.Zero otherwise.</param>
         /// <param name="partName">string name of the object, when transaction involves an object.  null otherwise.</param>
@@ -1714,7 +1714,7 @@ namespace Gloebit.GloebitMoneyModule
          * Any transaction which includes a local asset will receive callbacks at each transaction stage.
          * ENACT -> Funds have been transferred.  Process local asset (generally deliver a product)
          * CONSUME -> Funds have been released to recipient.  Finalize anything necessary.
-         * CANCEL -> Transaction has been cancelled.  Undo anything necessary
+         * CANCEL -> Transaction has been canceled.  Undo anything necessary
          */
 
         public bool processAssetEnactHold(GloebitTransaction txn, out string returnMsg) {
@@ -2031,8 +2031,8 @@ namespace Gloebit.GloebitMoneyModule
             IClientAPI client = LocateClientObject(UUID.Parse(user.PrincipalID));
             string title = "AUTHORIZE GLOEBIT";
             string body = "To use Gloebit currency, please authorize Gloebit to link to your avatar's account on this web page:";
-			
-			SendUrlToClient(client, title, body, authorizeUri);
+
+            SendUrlToClient(client, title, body, authorizeUri);
         }
 
         /// <summary>
@@ -2148,7 +2148,7 @@ namespace Gloebit.GloebitMoneyModule
 
                 // Deliver Purchase URI in case the helper-uri is not working
                 Uri url = m_apiW.BuildPurchaseURI (BaseURI, user);
-                SendUrlToClient (client, "Gloebit Authorization Successful", "Buy Gloebits you can spend on this grid:", url);
+                SendUrlToClient (client, "Gloebit Authorization Successful", "Buy gloebits you can spend on this grid:", url);
             }
         }
 
@@ -2677,7 +2677,7 @@ namespace Gloebit.GloebitMoneyModule
             // Validate that is the client sent the proper sale type the object has set
             if (saleType < 1 || saleType > 3) {
                 // Should not get here unless an object purchase is submitted with a bad or new (but unimplemented) saleType.
-                m_log.ErrorFormat("[GLOEBITMONEYMODULE] ObjectBuy Unrecognised saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", saleType);
+                m_log.ErrorFormat("[GLOEBITMONEYMODULE] ObjectBuy Unrecognized saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", saleType);
                 alertUsersTransactionPreparationFailure(TransactionType.USER_BUYS_OBJECT, TransactionPrecheckFailure.SALE_TYPE_INVALID, remoteClient);
                 return;
             }
@@ -3534,14 +3534,14 @@ namespace Gloebit.GloebitMoneyModule
             if (m_environment == GLBEnv.Sandbox) {
                 msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module in Sandbox Mode for testing.  All payments and transactions are fake.  Try it out.", client.Name);
             } else if (m_environment == GLBEnv.Production) {
-                msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module.  You can transact with Gloebits.", client.Name);
+                msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module.  You can transact with gloebits.", client.Name);
             } else {
                 msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module in a Custom Devloper Mode.", client.Name);
             }
             // Add instructions for clicking balance to see auth or purchase url
             // TODO: Should this be a separate message?
             if (user.IsAuthed()) {
-                msg = String.Format("{0}\nClick on your balance in the top right to purchase more Gloebits.", msg);
+                msg = String.Format("{0}\nClick on your balance in the top right to purchase more gloebits.", msg);
             } else {
                 msg = String.Format("{0}\nClick on your balance in the top right to link this avatar on this app to your Gloebit account.", msg);
 
@@ -3554,14 +3554,14 @@ namespace Gloebit.GloebitMoneyModule
             Thread welcomeMessageThread = new Thread(delegate() {
                 Thread.Sleep(delay * 1000);  // Delay milliseconds
                 // Deliver welcome message if we have popups enabled
-				if (m_showWelcomeMessage)
-					sendMessageToClient(client, msg, client.AgentId);
-				
-				// If authed, delivery url where user can purchase Gloebits
+                if (m_showWelcomeMessage)
+                    sendMessageToClient(client, msg, client.AgentId);
+
+                // If authed, delivery url where user can purchase Gloebits
                 if (user.IsAuthed()) {
                     if (m_showNewSessionPurchaseIM) {
                         Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);
-                        SendUrlToClient(client, "How to purchase Gloebits:", "Buy Gloebits you can spend in this area:", url);
+                        SendUrlToClient(client, "How to purchase gloebits:", "Buy gloebits you can spend in this area:", url);
                     }
                 } else {
                     if (m_showNewSessionAuthIM) {
@@ -3614,7 +3614,7 @@ namespace Gloebit.GloebitMoneyModule
                 // build txn details string
                 string paymentFrom = String.Format("Payment from: {0}", txn.PayerName);
                 string paymentTo = String.Format("Payment to: {0}", txn.PayeeName);
-                string amountStr = String.Format("Amount: {0:n0} Gloebits", txn.Amount);
+                string amountStr = String.Format("Amount: {0:n0} gloebits", txn.Amount);
                 // TODO: add description back in once txn includes it.
                 // string descStr = String.Format("Description: {0}", description);
                 string txnDetails = String.Format("Details:\n   {0}\n   {1}\n   {2}", paymentFrom, paymentTo, amountStr/*, descStr*/);
@@ -3640,7 +3640,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="payerID">UUID of payer from transaction that triggered this alert.</param>
         /// <param name="payeeID">UUID of payee from transaction that triggered this alert.</param>
-        /// <param name="amount">Int amount of Gloebits from transaction that triggered this alert.</param>
+        /// <param name="amount">Int amount of gloebits from transaction that triggered this alert.</param>
         /// <param name="subName">String name of subscription being sent to Gloebit for creation.</param>
         /// <param name="subDesc">String description of subscription being sent to Gloebit for creation.</param> 
         private void alertUsersSubscriptionTransactionFailedForSubscriptionCreation(UUID payerID, UUID payeeID, int amount, string subName, string subDesc)
@@ -3663,7 +3663,7 @@ namespace Gloebit.GloebitMoneyModule
         /// </summary>
         /// <param name="payerID">UUID of payer from transaction that triggered this alert.</param>
         /// <param name="payeeID">UUID of payee from transaction that triggered this alert.</param>
-        /// <param name="amount">Int amount of Gloebits from transaction that triggered this alert.</param>
+        /// <param name="amount">Int amount of gloebits from transaction that triggered this alert.</param>
         /// <param name="sub">GloebitSubscription that triggered this alert.</param>
         private void alertUsersSubscriptionTransactionFailedForGloebitAuthorization(UUID payerID, UUID payeeID, int amount, GloebitSubscription sub)
         {
@@ -3852,7 +3852,7 @@ namespace Gloebit.GloebitMoneyModule
                             break;
                         default:
                             // Should not get here as this should fail before transaction is built.
-                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] Transaction Begun With Unrecognised saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", txn.SaleType);
+                            m_log.ErrorFormat("[GLOEBITMONEYMODULE] Transaction Begun With Unrecognized saleType:{0} --- expected 1,2 or 3 for original, copy, or contents", txn.SaleType);
                             // TODO: Assert this.
                             //assert(txn.TransactionType >= 1 && txn.TransactionType <= 3);
                             break;
@@ -3966,13 +3966,13 @@ namespace Gloebit.GloebitMoneyModule
                     status = "Successfully submitted to Gloebit service.";
                     break;
                 case GloebitAPI.TransactionStage.QUEUE:
-                    // a) queued and Gloebits transferred.
+                    // a) queued and gloebits transferred.
                     // b) resubmitted
                     // c) queued, but early enact failure
                     status = "Successfully received by Gloebit and queued for processing.";
                     break;
                 case GloebitAPI.TransactionStage.ENACT_GLOEBIT:
-                    status = "Successfully transferred Gloebits.";
+                    status = "Successfully transferred gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.ENACT_ASSET:
                     switch ((TransactionType)txn.TransactionType) {
@@ -4045,16 +4045,16 @@ namespace Gloebit.GloebitMoneyModule
                     }
                     break;
                 case GloebitAPI.TransactionStage.CONSUME_GLOEBIT:
-                    status = "Successfully finalized transfer of Gloebits.";
+                    status = "Successfully finalized transfer of gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.CONSUME_ASSET:
                     status = "Successfully finalized local components of transaction.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_GLOEBIT:
-                    status = "Successfully cancelled and rolled back transfer of Gloebits.";
+                    status = "Successfully canceled and rolled back transfer of gloebits.";
                     break;
                 case GloebitAPI.TransactionStage.CANCEL_ASSET:
-                    status = "Successfully cancelled and rolled back local components of transaction.";
+                    status = "Successfully canceled and rolled back local components of transaction.";
                     break;
                 default:
                     m_log.ErrorFormat("[GLOEBITMONEYMODULE] alertUsersTransactionStageCompleted called on unhandled transaction stage : {0}", stage);
@@ -4174,11 +4174,11 @@ namespace Gloebit.GloebitMoneyModule
                             // message payer and payee
                             // TODO: Is it a privacy issue to alert buyer here?
                             // TODO: research if/when account is in this state.  Only by admin?  All accounts until merchants?
-                            error = "Payee's Gloebit account is unable to receive Gloebits.";
+                            error = "Payee's Gloebit account is unable to receive gloebits.";
                             instruction = contactPayee;
                             payeeInstruction = String.Format("Please contact {0} to address this issue", m_contactGloebit);
                             messagePayee = true;
-                            payeeMessage = String.Format("Gloebit:\nAttempt to pay you failed because your Gloebit account cannot receive Gloebits.\n\n{0}", payeeInstruction);
+                            payeeMessage = String.Format("Gloebit:\nAttempt to pay you failed because your Gloebit account cannot receive gloebits.\n\n{0}", payeeInstruction);
                             break;
                         default:
                             m_log.ErrorFormat("[GLOEBITMONEYMODULE] alertUsersTransactionFailed called on unhandled validation failure : {0}", failure);
@@ -4194,11 +4194,11 @@ namespace Gloebit.GloebitMoneyModule
                     break;
                 case GloebitAPI.TransactionStage.ENACT_GLOEBIT:
                     // We get these through early-enact failures via GloebitAPIWrapper.transactU2UCompleted call -> AlertTransactionFailed
-                    error = "Transfer of Gloebits failed.";
+                    error = "Transfer of gloebits failed.";
                     switch (failure) {
                         case GloebitAPI.TransactionFailure.INSUFFICIENT_FUNDS:
                             error = String.Format("{0}  Insufficient funds.", error);
-                            instruction = "Go to https://www.gloebit.com/purchase to get more Gloebits.";
+                            instruction = "Go to https://www.gloebit.com/purchase to get more gloebits.";
                             payeeInstruction = contactPayer;    // not considering privacy issue since caused by auto-debit and payer would want to know of failure.
                             break;
                         default:

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -63,6 +63,8 @@
  * this file will likely require major modification or replacement.
  */
 
+#define NEWHTTPFLOW
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -547,7 +549,9 @@ namespace Gloebit.GloebitMoneyModule
         // Helper funciton used in AddRegion for post 0.9.2.0 XML RPC Handlers 
         public void processPHP(IOSHttpRequest request, IOSHttpResponse response)
         {
+#if NEWHTTPFLOW
             MainServer.Instance.HandleXmlRpcRequests((OSHttpRequest)request, (OSHttpResponse)response, m_rpcHandlers);
+#endif
         }
 
         public void AddRegion(Scene scene)
@@ -598,8 +602,10 @@ namespace Gloebit.GloebitMoneyModule
                             m_rpcHandlers.Add("buyCurrency", buy_func);
                             m_rpcHandlers.Add("preflightBuyLandPrep", preflightBuyLandPrep_func);
                             m_rpcHandlers.Add("buyLandPrep", landBuy_func);
+#if NEWHTTPFLOW
                             MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/landtool.php", processPHP));
                             MainServer.Instance.AddSimpleStreamHandler(new SimpleStreamHandler("/currency.php", processPHP));
+#endif
                         } else {
                             httpServer.AddXmlRPCHandler("getCurrencyQuote", quote_func);
                             httpServer.AddXmlRPCHandler("buyCurrency", buy_func);

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -429,7 +429,7 @@ namespace Gloebit.GloebitMoneyModule
                 }
                 // Should we disable adding info to OpenSimExtras map
                 m_disablePerSimCurrencyExtras = config.GetBoolean("DisablePerSimCurrencyExtras", false);
-                // Should we send new session IMs informing user how to auth or purchase gloebits
+                // Should we send new session IMs informing user how to auth or purchase Gloebits
                 m_showNewSessionPurchaseIM = config.GetBoolean("GLBShowNewSessionPurchaseIM", false);
                 m_showNewSessionAuthIM = config.GetBoolean("GLBShowNewSessionAuthIM", true);
                 // Are we using custom db connection info
@@ -576,7 +576,7 @@ namespace Gloebit.GloebitMoneyModule
 
                         // These functions can handle the calls to the economy helper-uri if it is configured to point at the sim.  
                         // They will enable land purchasing, buy-currency, and insufficient-funds flows.
-                        // *NOTE* gloebits can not currently be purchased from a viewer, but this allows Gloebit to control the
+                        // *NOTE* Gloebits can not currently be purchased from a viewer, but this allows Gloebit to control the
                         // messaging in this flow and send users to the Gloebit website for purchasing.
                         httpServer.AddXmlRPCHandler("getCurrencyQuote", quote_func);
                         httpServer.AddXmlRPCHandler("buyCurrency", buy_func);
@@ -2531,7 +2531,7 @@ namespace Gloebit.GloebitMoneyModule
                 return;
             }
 
-            /******** Set up necessary parts for gloebit transact-u2u **********/
+            /******** Set up necessary parts for Gloebit transact-u2u **********/
 
             GloebitTransaction txn = buildTransaction(transactionID: UUID.Zero, transactionType: (TransactionType)e.transactiontype,
                 payerID: fromID, payeeID: toID, amount: e.amount, subscriptionID: UUID.Zero,
@@ -3448,14 +3448,14 @@ namespace Gloebit.GloebitMoneyModule
             if (m_environment == GLBEnv.Sandbox) {
                 msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module in Sandbox Mode for testing.  All payments and transactions are fake.  Try it out.", client.Name);
             } else if (m_environment == GLBEnv.Production) {
-                msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module.  You can transact with gloebits.", client.Name);
+                msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module.  You can transact with Gloebits.", client.Name);
             } else {
                 msg = String.Format("Welcome {0}.  This area is using the Gloebit Money Module in a Custom Devloper Mode.", client.Name);
             }
             // Add instructions for clicking balance to see auth or purchase url
             // TODO: Should this be a separate message?
             if (user.IsAuthed()) {
-                msg = String.Format("{0}\nClick on your balance in the top right to purchase more gloebits.", msg);
+                msg = String.Format("{0}\nClick on your balance in the top right to purchase more Gloebits.", msg);
             } else {
                 msg = String.Format("{0}\nClick on your balance in the top right to link this avatar on this app to your Gloebit account.", msg);
 
@@ -3469,7 +3469,7 @@ namespace Gloebit.GloebitMoneyModule
                 Thread.Sleep(delay * 1000);  // Delay milliseconds
                 // Deliver welcome message
                 sendMessageToClient(client, msg, client.AgentId);
-                // If authed, delivery url where user can purchase gloebits
+                // If authed, delivery url where user can purchase Gloebits
                 if (user.IsAuthed()) {
                     if (m_showNewSessionPurchaseIM) {
                         Uri url = m_apiW.BuildPurchaseURI(BaseURI, user);
@@ -3526,7 +3526,7 @@ namespace Gloebit.GloebitMoneyModule
                 // build txn details string
                 string paymentFrom = String.Format("Payment from: {0}", txn.PayerName);
                 string paymentTo = String.Format("Payment to: {0}", txn.PayeeName);
-                string amountStr = String.Format("Amount: {0:n0} gloebits", txn.Amount);
+                string amountStr = String.Format("Amount: {0:n0} Gloebits", txn.Amount);
                 // TODO: add description back in once txn includes it.
                 // string descStr = String.Format("Description: {0}", description);
                 string txnDetails = String.Format("Details:\n   {0}\n   {1}\n   {2}", paymentFrom, paymentTo, amountStr/*, descStr*/);
@@ -3878,7 +3878,7 @@ namespace Gloebit.GloebitMoneyModule
                     status = "Successfully submitted to Gloebit service.";
                     break;
                 case GloebitAPI.TransactionStage.QUEUE:
-                    // a) queued and gloebits transferred.
+                    // a) queued and Gloebits transferred.
                     // b) resubmitted
                     // c) queued, but early enact failure
                     status = "Successfully received by Gloebit and queued for processing.";

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitMoneyModule.cs
@@ -694,7 +694,7 @@ namespace Gloebit.GloebitMoneyModule
 			int vn1 = 0;
 			int vn2 = 0;
 			int vn3 = 0;
-			int vn4 = 0;
+			int vn4 = -9999;
             m_opensimVersion = OpenSim.VersionInfo.Version;
             m_opensimVersionNumber = OpenSim.VersionInfo.VersionNumber;
             char[] delimiterChars = { '.' };
@@ -706,6 +706,10 @@ namespace Gloebit.GloebitMoneyModule
 			} catch {
 				m_log.DebugFormat("[GLOEBITMONEYMODULE] Unable to parse version information, Gloebit cannot handle unofficial versions");
 			}
+			try {
+					vn4 = int.Parse(numbers[3]);
+				}
+			catch {}
 			
             if ((vn1 > 0) || (vn2 > 9) || (vn2 == 9 && vn3 > 0)) {
                 // 0.9.1 and beyond are the new land pass flow.
@@ -715,10 +719,6 @@ namespace Gloebit.GloebitMoneyModule
             } else if (vn1 == 0 && vn2 == 9 && vn3 == 0) {
                 // 0.9.0-release pulled in 0.9.1 changes and is new flow, but rest of 0.9.0 is not.
                 // assume dev on 0.9.0.1, 0.9.0.2 will be new flow
-				try {
-					vn4 = int.Parse(numbers[3]);
-				}
-				catch {}
                 if (vn4 > 0) {
                     // 0.9.0.1, 0.9.0.2, etc.
                     m_newLandPassFlow = true;
@@ -739,7 +739,7 @@ namespace Gloebit.GloebitMoneyModule
 			// Test for version 0.9.2.0 which contains changes to httpserver and thus needs different workflows also
 			// This is a really bad way to check which method to use as these changes are not directly related to version numbers
 			// Rather these changes also concern libomv and should be tested for by directly testing available methods of httpserver
-			if ((vn2 > 9) &% (vn3 > 1))
+			if (((vn2 == 9 && vn3 == 2) || (vn2 > 9 && vn3 > 2)) && vn4 != -9999)
 			{
 				m_newHTTPFlow = true;
 			}

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
@@ -32,8 +32,8 @@ using OpenMetaverse;
 
 namespace Gloebit.GloebitMoneyModule {
 
-	// Compiler complains about not declaring an override for GetHashCode, but we don't use that so we'll just tell it to stop complaining		
-	#pragma warning disable 0659
+    // Compiler complains about not declaring an override for GetHashCode, but we don't use that so we'll just tell it to stop complaining		
+    #pragma warning disable 0659
 
     public class GloebitSubscription {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -255,7 +255,7 @@ namespace Gloebit.GloebitMoneyModule {
             //m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND SUBSCRIPTION in cache! oID:{0} appKey:{1} url:{2} sID:{3} oN:{4} oD:{5}", subscription.ObjectID, subscription.AppKey, subscription.GlbApiUrl, subscription.SubscriptionID, subscription.ObjectName, subscription.Description);
             //return subscription;
         }
-		
+
         public override bool Equals(Object obj)
         {
             //Check for null and compare run-time types.
@@ -288,7 +288,7 @@ namespace Gloebit.GloebitMoneyModule {
                     (Enabled == s.Enabled));
             }
         }
-	}
-	#pragma warning restore 0659
+    }
+    #pragma warning restore 0659
 }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitSubscription.cs
@@ -32,6 +32,9 @@ using OpenMetaverse;
 
 namespace Gloebit.GloebitMoneyModule {
 
+	// Compiler complains about not declaring an override for GetHashCode, but we don't use that so we'll just tell it to stop complaining		
+	#pragma warning disable 0659
+
     public class GloebitSubscription {
         private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -252,7 +255,7 @@ namespace Gloebit.GloebitMoneyModule {
             //m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND SUBSCRIPTION in cache! oID:{0} appKey:{1} url:{2} sID:{3} oN:{4} oD:{5}", subscription.ObjectID, subscription.AppKey, subscription.GlbApiUrl, subscription.SubscriptionID, subscription.ObjectName, subscription.Description);
             //return subscription;
         }
-
+		
         public override bool Equals(Object obj)
         {
             //Check for null and compare run-time types.
@@ -285,6 +288,7 @@ namespace Gloebit.GloebitMoneyModule {
                     (Enabled == s.Enabled));
             }
         }
-    }
+	}
+	#pragma warning restore 0659
 }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
@@ -53,7 +53,7 @@ namespace Gloebit.GloebitMoneyModule {
         public bool IsSubscriptionDebit;
         public UUID SubscriptionID;
 
-        // Object info required when enacting/consume/canceling, delivering, and handling subscriptions
+        // Object info required when enacting/consume/cancelling, delivering, and handling subscriptions
         public UUID PartID;         // UUID of object
         public string PartName;     // object name
         public string PartDescription;
@@ -126,7 +126,7 @@ namespace Gloebit.GloebitMoneyModule {
             this.PayerEndingBalance = -1;
 
 
-            // Object info required when enacting/consume/canceling, delivering, and handling subscriptions
+            // Object info required when enacting/consume/cancelling, delivering, and handling subscriptions
             this.PartID = partID;
             this.PartName = partName;
             this.PartDescription = partDescription;
@@ -146,10 +146,10 @@ namespace Gloebit.GloebitMoneyModule {
             this.enactedTime = null; // set to null instead of DateTime.MinValue to avoid crash on reading 0 timestamp
             this.finishedTime = null; // set to null instead of DateTime.MinValue to avoid crash on reading 0 timestamp
             // TODO: We have made these nullable and initialize to null.  We could alternatively choose a time that is not zero
-            // and avoid any potential conficts from allowing null.
+            // and avoid any potential conflicts from allowing null.
             // On MySql, I had to set the columns to allow NULL, otherwise, inserting null defaulted to the current local time.
             // On PGSql, I set the columns to allow NULL, but haven't tested.
-            // On SQLite, I don't think that you can set them to allow NULL explicitely, and haven't checked defaults.
+            // On SQLite, I don't think that you can set them to allow NULL explicitly, and haven't checked defaults.
         }
 
         // Creates a new transaction
@@ -301,7 +301,7 @@ namespace Gloebit.GloebitMoneyModule {
                 break;
             default:
                 // no recognized state request
-                returnMsg = "Unrecognized state request";
+                returnMsg = "Unrecognised state request";
                 result = false;
                 break;
             }
@@ -317,7 +317,7 @@ namespace Gloebit.GloebitMoneyModule {
         {
             if (this.canceled) {
                 // getting a delayed enact sent before cancel.  return false.
-                returnMsg = "Enact: already canceled";
+                returnMsg = "Enact: already cancelled";
                 return false;
             }
             if (this.consumed) {
@@ -350,7 +350,7 @@ namespace Gloebit.GloebitMoneyModule {
                 m_log.DebugFormat("PayerEndingBalance: {0}", this.PayerEndingBalance);
                 m_log.DebugFormat("enacted: {0}", this.enacted);
                 m_log.DebugFormat("consumed: {0}", this.consumed);
-                m_log.DebugFormat("canceled: {0}", this.canceled);
+                m_log.DebugFormat("cancelled: {0}", this.canceled);
                 m_log.DebugFormat("cTime: {0}", this.cTime);
                 m_log.DebugFormat("enactedTime: {0}", this.enactedTime);
                 m_log.DebugFormat("finishedTime: {0}", this.finishedTime);
@@ -375,7 +375,7 @@ namespace Gloebit.GloebitMoneyModule {
         {
             if (this.canceled) {
                 // Should never get a delayed consume after a cancel.  return false.
-                returnMsg = "Consume: already canceled";
+                returnMsg = "Consume: already cancelled";
                 return false;
             }
             if (!this.enacted) {
@@ -385,7 +385,7 @@ namespace Gloebit.GloebitMoneyModule {
             }
             if (this.consumed) {
                 // already consumed. return true.
-                returnMsg = "Cosume: Already consumed";
+                returnMsg = "Consume: Already consumed";
                 return true;
             }
 
@@ -421,8 +421,8 @@ namespace Gloebit.GloebitMoneyModule {
                 //return true;
             }
             if (this.canceled) {
-                // already canceled. return true.
-                returnMsg = "Cancel: already canceled";
+                // already cancelled. return true.
+                returnMsg = "Cancel: already cancelled";
                 return true;
             }
             // First reception of cancel for asset.

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransaction.cs
@@ -53,7 +53,7 @@ namespace Gloebit.GloebitMoneyModule {
         public bool IsSubscriptionDebit;
         public UUID SubscriptionID;
 
-        // Object info required when enacting/consume/cancelling, delivering, and handling subscriptions
+        // Object info required when enacting/consume/canceling, delivering, and handling subscriptions
         public UUID PartID;         // UUID of object
         public string PartName;     // object name
         public string PartDescription;
@@ -126,7 +126,7 @@ namespace Gloebit.GloebitMoneyModule {
             this.PayerEndingBalance = -1;
 
 
-            // Object info required when enacting/consume/cancelling, delivering, and handling subscriptions
+            // Object info required when enacting/consume/canceling, delivering, and handling subscriptions
             this.PartID = partID;
             this.PartName = partName;
             this.PartDescription = partDescription;
@@ -301,7 +301,7 @@ namespace Gloebit.GloebitMoneyModule {
                 break;
             default:
                 // no recognized state request
-                returnMsg = "Unrecognised state request";
+                returnMsg = "Unrecognized state request";
                 result = false;
                 break;
             }
@@ -317,7 +317,7 @@ namespace Gloebit.GloebitMoneyModule {
         {
             if (this.canceled) {
                 // getting a delayed enact sent before cancel.  return false.
-                returnMsg = "Enact: already cancelled";
+                returnMsg = "Enact: already canceled";
                 return false;
             }
             if (this.consumed) {
@@ -350,7 +350,7 @@ namespace Gloebit.GloebitMoneyModule {
                 m_log.DebugFormat("PayerEndingBalance: {0}", this.PayerEndingBalance);
                 m_log.DebugFormat("enacted: {0}", this.enacted);
                 m_log.DebugFormat("consumed: {0}", this.consumed);
-                m_log.DebugFormat("cancelled: {0}", this.canceled);
+                m_log.DebugFormat("canceled: {0}", this.canceled);
                 m_log.DebugFormat("cTime: {0}", this.cTime);
                 m_log.DebugFormat("enactedTime: {0}", this.enactedTime);
                 m_log.DebugFormat("finishedTime: {0}", this.finishedTime);
@@ -375,7 +375,7 @@ namespace Gloebit.GloebitMoneyModule {
         {
             if (this.canceled) {
                 // Should never get a delayed consume after a cancel.  return false.
-                returnMsg = "Consume: already cancelled";
+                returnMsg = "Consume: already canceled";
                 return false;
             }
             if (!this.enacted) {
@@ -421,8 +421,8 @@ namespace Gloebit.GloebitMoneyModule {
                 //return true;
             }
             if (this.canceled) {
-                // already cancelled. return true.
-                returnMsg = "Cancel: already cancelled";
+                // already canceled. return true.
+                returnMsg = "Cancel: already canceled";
                 return true;
             }
             // First reception of cancel for asset.

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -146,10 +146,9 @@ namespace Gloebit.GloebitMoneyModule
 				}
 				catch(Exception e)
 				{
-					m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data");
+					m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data: {0}", e);
 					return false;
 				}
-				return false;
             }
         }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -162,7 +162,7 @@ namespace Gloebit.GloebitMoneyModule
             
             public override bool Store(GloebitTransaction txn)
             {
-		try {
+		        try {
                     // remove null datetimes as pgsql throws exceptions on null fields
                     if (txn.enactedTime == null) {
                         txn.enactedTime = SqlDateTime.MinValue.Value;
@@ -173,10 +173,13 @@ namespace Gloebit.GloebitMoneyModule
                     //m_log.InfoFormat("GloebitTransactionData.PGSQLImpl: storing transaction type:{0}, SaleType:{2}, PayerEndingBalance:{3}, cTime:{4}, enactedTime:{5}, finishedTime:{6}", txn.TransactionType, txn.SaleType, txn.PayerEndingBalance, txn.cTime, txn.enactedTime, txn.finishedTime);
                     // call parent
                     return base.Store(txn);
-		} catch(System.OverflowException e) {
+		        } catch(System.OverflowException e) {
                     m_log.ErrorFormat("GloebitTransactionData.PGSQLImpl: Failure storing transaction type:{0}, SaleType:{1}, PayerEndingBalance:{2}, cTime:{3}, enactedTime:{4}, finishedTime:{5}, stacktrace:{6}", txn.TransactionType, txn.SaleType, txn.PayerEndingBalance, txn.cTime, txn.enactedTime, txn.finishedTime, e);
-		    throw;
-		}
+		            return false;
+		        } catch(Exception e) {
+                    m_log.DebugFormat("[PGSQL GENERIC TABLE HANDLER]: Failed to store data: {0}", e);
+                    return false;
+                }
             }
         }
         

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -33,7 +33,7 @@ using OpenSim.Data.SQLite;
 namespace Gloebit.GloebitMoneyModule
 {
     class GloebitTransactionData {
-		private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private static IGloebitTransactionData m_impl;
 
@@ -94,61 +94,61 @@ namespace Gloebit.GloebitMoneyModule
             public override bool Store(GloebitTransaction txn)
             {
                 //            m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Store(T row) invoked");
-				
-				try
-				{
+
+                try
+                {
                 
-					using (MySqlCommand cmd = new MySqlCommand())
-					{
-						string query = "";
-						List<String> names = new List<String>();
-						List<String> values = new List<String>();
-						
-						foreach (FieldInfo fi in m_Fields.Values)
-						{
-							names.Add(fi.Name);
-							values.Add("?" + fi.Name);
-							
-							// Temporarily return more information about what field is unexpectedly null for
-							// http://opensimulator.org/mantis/view.php?id=5403.  This might be due to a bug in the
-							// InventoryTransferModule or we may be required to substitute a DBNull here.
-							/*if (fi.GetValue(asset) == null)
-								throw new NullReferenceException(
-																string.Format(
-																			"[MYSQL GENERIC TABLE HANDLER]: Trying to store field {0} for {1} which is unexpectedly null",
-																			fi.Name, asset));*/
-							
-							cmd.Parameters.AddWithValue(fi.Name, fi.GetValue(txn));
-						}
-						
-						/*if (m_DataField != null)
-						{
-							Dictionary<string, string> data =
-							(Dictionary<string, string>)m_DataField.GetValue(row);
-							
-							foreach (KeyValuePair<string, string> kvp in data)
-							{
-								names.Add(kvp.Key);
-								values.Add("?" + kvp.Key);
-								cmd.Parameters.AddWithValue("?" + kvp.Key, kvp.Value);
-							}
-						}*/
-						
-						query = String.Format("replace into {0} (`", m_Realm) + String.Join("`,`", names.ToArray()) + "`) values (" + String.Join(",", values.ToArray()) + ")";
-						
-						cmd.CommandText = query;
-						
-						if (ExecuteNonQuery(cmd) > 0)
-							return true;
-						
-						return false;
-					}
-				}
-				catch(Exception e)
-				{
-					m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data: {0}", e);
-					return false;
-				}
+                    using (MySqlCommand cmd = new MySqlCommand())
+                    {
+                        string query = "";
+                        List<String> names = new List<String>();
+                        List<String> values = new List<String>();
+
+                        foreach (FieldInfo fi in m_Fields.Values)
+                        {
+                            names.Add(fi.Name);
+                            values.Add("?" + fi.Name);
+
+                            // Temporarily return more information about what field is unexpectedly null for
+                            // http://opensimulator.org/mantis/view.php?id=5403.  This might be due to a bug in the
+                            // InventoryTransferModule or we may be required to substitute a DBNull here.
+                            /*if (fi.GetValue(asset) == null)
+                                throw new NullReferenceException(
+                                                                string.Format(
+                                                                            "[MYSQL GENERIC TABLE HANDLER]: Trying to store field {0} for {1} which is unexpectedly null",
+                                                                            fi.Name, asset));*/
+
+                            cmd.Parameters.AddWithValue(fi.Name, fi.GetValue(txn));
+                        }
+
+                        /*if (m_DataField != null)
+                        {
+                            Dictionary<string, string> data =
+                            (Dictionary<string, string>)m_DataField.GetValue(row);
+
+                            foreach (KeyValuePair<string, string> kvp in data)
+                            {  
+                                names.Add(kvp.Key);
+                                values.Add("?" + kvp.Key);
+                                cmd.Parameters.AddWithValue("?" + kvp.Key, kvp.Value);
+                            }
+                        }*/
+
+                        query = String.Format("replace into {0} (`", m_Realm) + String.Join("`,`", names.ToArray()) + "`) values (" + String.Join(",", values.ToArray()) + ")";
+
+                        cmd.CommandText = query;
+
+                        if (ExecuteNonQuery(cmd) > 0)
+                            return true;
+
+                        return false;
+                    }
+                }
+                catch(Exception e)
+                {
+                    m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data: {0}", e);
+                    return false;
+                }
             }
         }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -93,52 +93,60 @@ namespace Gloebit.GloebitMoneyModule
             public override bool Store(GloebitTransaction txn)
             {
                 //            m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Store(T row) invoked");
+				
+				try
+				{
                 
-                using (MySqlCommand cmd = new MySqlCommand())
-                {
-                    string query = "";
-                    List<String> names = new List<String>();
-                    List<String> values = new List<String>();
-                    
-                    foreach (FieldInfo fi in m_Fields.Values)
-                    {
-                        names.Add(fi.Name);
-                        values.Add("?" + fi.Name);
-                        
-                        // Temporarily return more information about what field is unexpectedly null for
-                        // http://opensimulator.org/mantis/view.php?id=5403.  This might be due to a bug in the
-                        // InventoryTransferModule or we may be required to substitute a DBNull here.
-                        /*if (fi.GetValue(asset) == null)
-                            throw new NullReferenceException(
-                                                             string.Format(
-                                                                           "[MYSQL GENERIC TABLE HANDLER]: Trying to store field {0} for {1} which is unexpectedly null",
-                                                                           fi.Name, asset));*/
-                        
-                        cmd.Parameters.AddWithValue(fi.Name, fi.GetValue(txn));
-                    }
-                    
-                    /*if (m_DataField != null)
-                    {
-                        Dictionary<string, string> data =
-                        (Dictionary<string, string>)m_DataField.GetValue(row);
-                        
-                        foreach (KeyValuePair<string, string> kvp in data)
-                        {
-                            names.Add(kvp.Key);
-                            values.Add("?" + kvp.Key);
-                            cmd.Parameters.AddWithValue("?" + kvp.Key, kvp.Value);
-                        }
-                    }*/
-                    
-                    query = String.Format("replace into {0} (`", m_Realm) + String.Join("`,`", names.ToArray()) + "`) values (" + String.Join(",", values.ToArray()) + ")";
-                    
-                    cmd.CommandText = query;
-                    
-                    if (ExecuteNonQuery(cmd) > 0)
-                        return true;
-                    
-                    return false;
-                }
+					using (MySqlCommand cmd = new MySqlCommand())
+					{
+						string query = "";
+						List<String> names = new List<String>();
+						List<String> values = new List<String>();
+						
+						foreach (FieldInfo fi in m_Fields.Values)
+						{
+							names.Add(fi.Name);
+							values.Add("?" + fi.Name);
+							
+							// Temporarily return more information about what field is unexpectedly null for
+							// http://opensimulator.org/mantis/view.php?id=5403.  This might be due to a bug in the
+							// InventoryTransferModule or we may be required to substitute a DBNull here.
+							/*if (fi.GetValue(asset) == null)
+								throw new NullReferenceException(
+																string.Format(
+																			"[MYSQL GENERIC TABLE HANDLER]: Trying to store field {0} for {1} which is unexpectedly null",
+																			fi.Name, asset));*/
+							
+							cmd.Parameters.AddWithValue(fi.Name, fi.GetValue(txn));
+						}
+						
+						/*if (m_DataField != null)
+						{
+							Dictionary<string, string> data =
+							(Dictionary<string, string>)m_DataField.GetValue(row);
+							
+							foreach (KeyValuePair<string, string> kvp in data)
+							{
+								names.Add(kvp.Key);
+								values.Add("?" + kvp.Key);
+								cmd.Parameters.AddWithValue("?" + kvp.Key, kvp.Value);
+							}
+						}*/
+						
+						query = String.Format("replace into {0} (`", m_Realm) + String.Join("`,`", names.ToArray()) + "`) values (" + String.Join(",", values.ToArray()) + ")";
+						
+						cmd.CommandText = query;
+						
+						if (ExecuteNonQuery(cmd) > 0)
+							return true;
+						
+						return false;
+					}
+				}
+				catch(Exception e)
+				{
+					m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data");
+				}
             }
         }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -146,7 +146,9 @@ namespace Gloebit.GloebitMoneyModule
 				catch(Exception e)
 				{
 					m_log.DebugFormat("[MYSQL GENERIC TABLE HANDLER]: Failed to store data");
+					return false;
 				}
+				return false;
             }
         }
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitTransactionData.cs
@@ -33,6 +33,7 @@ using OpenSim.Data.SQLite;
 namespace Gloebit.GloebitMoneyModule
 {
     class GloebitTransactionData {
+		private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private static IGloebitTransactionData m_impl;
 

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -27,7 +27,7 @@
  * --- account.
  * Do not confuse this with representing a single local user, though this is
  * --- generally the case.  There can be multiple records for a sinlge local
- * --- account if this product has connected via multple Gloebit Apps, such as
+ * --- account if this product has connected via multiple Gloebit Apps, such as
  * --- to our Sandbox environment and to our Production environment.
  * This stores a record per user per Gloebit App (per OAuth Key).
  * --- The primary function here is to handle storage and retrieval of the

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -98,59 +98,59 @@ namespace Gloebit.GloebitMoneyModule {
             
         public static GloebitUser Get(string appKeyStr, string agentIdStr) {
             m_log.Info("[GLOEBITMONEYMODULE] in GloebitUser.Get");
-			
-			try
-			{
-				GloebitUser u;
-				lock(s_userMap) {
-					s_userMap.TryGetValue(agentIdStr, out u);
-				}
-	
-				if (u == null) {
-					m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
-					string[] keys = new string[2]{"AppKey", "PrincipalID"};
-					string[] values = new string[2]{appKeyStr, agentIdStr};
-					GloebitUser[] users = GloebitUserData.Instance.Get(keys, values);
-	
-					switch(users.Length) {
-					case 1:
-						u = users[0];
-						m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
-						break;
-					case 0:
-						m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
-						u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
-						break;
-					default:
-						throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
-					}
-	
-					// Store in map and return GloebitUser
-					lock(s_userMap) {
-						// Make sure no one else has already loaded this user
-						GloebitUser alreadyLoadedUser;
-						s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
-						if (alreadyLoadedUser == null) {
-							s_userMap[agentIdStr] = u;
-						} else {
-							u = alreadyLoadedUser;
-						}
-					}
-				}
-	
-				// Create a thread local copy of the user to return.
-				GloebitUser localUser;
-				lock (u.userLock) {
-					localUser = new GloebitUser(u);
-				}
-	
-				return localUser;
-			}
-			catch(Exception e)
-			{
-				m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
-				return null;
-			}
+
+            try
+            {
+                GloebitUser u;
+                lock(s_userMap) {
+                    s_userMap.TryGetValue(agentIdStr, out u);
+                }
+
+                if (u == null) {
+                    m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
+                    string[] keys = new string[2]{"AppKey", "PrincipalID"};
+                    string[] values = new string[2]{appKeyStr, agentIdStr};
+                    GloebitUser[] users = GloebitUserData.Instance.Get(keys, values);
+
+                    switch(users.Length) {
+                    case 1:
+                        u = users[0];
+                        m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
+                        break;
+                    case 0:
+                        m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
+                        u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
+                        break;
+                    default:
+                        throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
+                    }
+
+                    // Store in map and return GloebitUser
+                    lock(s_userMap) {
+                        // Make sure no one else has already loaded this user
+                        GloebitUser alreadyLoadedUser;
+                        s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
+                        if (alreadyLoadedUser == null) {
+                            s_userMap[agentIdStr] = u;
+                        } else {
+                            u = alreadyLoadedUser;
+                        }
+                    }
+                }
+
+                // Create a thread local copy of the user to return.
+                GloebitUser localUser;
+                lock (u.userLock) {
+                    localUser = new GloebitUser(u);
+                }
+
+                return localUser;
+            }
+            catch(Exception e)
+            {
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
+                return null;
+            }
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -149,7 +149,9 @@ namespace Gloebit.GloebitMoneyModule {
 			catch(Exception e)
 			{
 				m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
+				return;
 			}
+			return;
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -149,9 +149,9 @@ namespace Gloebit.GloebitMoneyModule {
 			catch(Exception e)
 			{
 				m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
-				return;
+				return null;
 			}
-			return;
+			return null;
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -151,7 +151,6 @@ namespace Gloebit.GloebitMoneyModule {
 				m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
 				return null;
 			}
-			return null;
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -99,58 +99,56 @@ namespace Gloebit.GloebitMoneyModule {
         public static GloebitUser Get(string appKeyStr, string agentIdStr) {
             m_log.Info("[GLOEBITMONEYMODULE] in GloebitUser.Get");
 
-            try
-            {
-                GloebitUser u;
+            GloebitUser u;
+            lock(s_userMap) {
+                s_userMap.TryGetValue(agentIdStr, out u);
+            }
+
+            if (u == null) {
+                m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
+                string[] keys = new string[2]{"AppKey", "PrincipalID"};
+                string[] values = new string[2]{appKeyStr, agentIdStr};
+                GloebitUser[] users;
+                try {
+                    users = GloebitUserData.Instance.Get(keys, values);
+                } catch(Exception e) {
+                    m_log.WarnFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
+                    users = [];
+                }
+
+                switch(users.Length) {
+                case 1:
+                    u = users[0];
+                    m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
+                    break;
+                case 0:
+                    m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
+                    u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
+                    break;
+                default:
+                    throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
+                }
+
+                // Store in map and return GloebitUser
                 lock(s_userMap) {
-                    s_userMap.TryGetValue(agentIdStr, out u);
-                }
-
-                if (u == null) {
-                    m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
-                    string[] keys = new string[2]{"AppKey", "PrincipalID"};
-                    string[] values = new string[2]{appKeyStr, agentIdStr};
-                    GloebitUser[] users = GloebitUserData.Instance.Get(keys, values);
-
-                    switch(users.Length) {
-                    case 1:
-                        u = users[0];
-                        m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
-                        break;
-                    case 0:
-                        m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
-                        u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
-                        break;
-                    default:
-                        throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
-                    }
-
-                    // Store in map and return GloebitUser
-                    lock(s_userMap) {
-                        // Make sure no one else has already loaded this user
-                        GloebitUser alreadyLoadedUser;
-                        s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
-                        if (alreadyLoadedUser == null) {
-                            s_userMap[agentIdStr] = u;
-                        } else {
-                            u = alreadyLoadedUser;
-                        }
+                    // Make sure no one else has already loaded this user
+                    GloebitUser alreadyLoadedUser;
+                    s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
+                    if (alreadyLoadedUser == null) {
+                        s_userMap[agentIdStr] = u;
+                    } else {
+                        u = alreadyLoadedUser;
                     }
                 }
-
-                // Create a thread local copy of the user to return.
-                GloebitUser localUser;
-                lock (u.userLock) {
-                    localUser = new GloebitUser(u);
-                }
-
-                return localUser;
             }
-            catch(Exception e)
-            {
-                m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
-                return null;
+
+            // Create a thread local copy of the user to return.
+            GloebitUser localUser;
+            lock (u.userLock) {
+                localUser = new GloebitUser(u);
             }
+
+            return localUser;
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -98,51 +98,58 @@ namespace Gloebit.GloebitMoneyModule {
             
         public static GloebitUser Get(string appKeyStr, string agentIdStr) {
             m_log.Info("[GLOEBITMONEYMODULE] in GloebitUser.Get");
-
-            GloebitUser u;
-            lock(s_userMap) {
-                s_userMap.TryGetValue(agentIdStr, out u);
-            }
-
-            if (u == null) {
-                m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
-                string[] keys = new string[2]{"AppKey", "PrincipalID"};
-                string[] values = new string[2]{appKeyStr, agentIdStr};
-                GloebitUser[] users = GloebitUserData.Instance.Get(keys, values);
-
-                switch(users.Length) {
-                case 1:
-                    u = users[0];
-                    m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
-                    break;
-                case 0:
-                    m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
-                    u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
-                    break;
-                default:
-                    throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
-                }
-
-                // Store in map and return GloebitUser
-                lock(s_userMap) {
-                    // Make sure no one else has already loaded this user
-                    GloebitUser alreadyLoadedUser;
-                    s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
-                    if (alreadyLoadedUser == null) {
-                        s_userMap[agentIdStr] = u;
-                    } else {
-                        u = alreadyLoadedUser;
-                    }
-                }
-            }
-
-            // Create a thread local copy of the user to return.
-            GloebitUser localUser;
-            lock (u.userLock) {
-                localUser = new GloebitUser(u);
-            }
-
-            return localUser;
+			
+			try
+			{
+				GloebitUser u;
+				lock(s_userMap) {
+					s_userMap.TryGetValue(agentIdStr, out u);
+				}
+	
+				if (u == null) {
+					m_log.DebugFormat("[GLOEBITMONEYMODULE] Looking for prior user for {0}", agentIdStr);
+					string[] keys = new string[2]{"AppKey", "PrincipalID"};
+					string[] values = new string[2]{appKeyStr, agentIdStr};
+					GloebitUser[] users = GloebitUserData.Instance.Get(keys, values);
+	
+					switch(users.Length) {
+					case 1:
+						u = users[0];
+						m_log.DebugFormat("[GLOEBITMONEYMODULE] FOUND USER TOKEN! {0} valid token? {1} --- SesionID{2}", u.PrincipalID, !String.IsNullOrEmpty(u.GloebitToken), u.LastSessionID);
+						break;
+					case 0:
+						m_log.DebugFormat("[GLOEBITMONEYMODULE] CREATING NEW USER {0}", agentIdStr);
+						u = new GloebitUser(appKeyStr, agentIdStr, String.Empty, String.Empty, String.Empty);
+						break;
+					default:
+						throw new Exception(String.Format("[GLOEBITMONEYMODULE] Failed to find exactly one prior token for {0}", agentIdStr));
+					}
+	
+					// Store in map and return GloebitUser
+					lock(s_userMap) {
+						// Make sure no one else has already loaded this user
+						GloebitUser alreadyLoadedUser;
+						s_userMap.TryGetValue(agentIdStr, out alreadyLoadedUser);
+						if (alreadyLoadedUser == null) {
+							s_userMap[agentIdStr] = u;
+						} else {
+							u = alreadyLoadedUser;
+						}
+					}
+				}
+	
+				// Create a thread local copy of the user to return.
+				GloebitUser localUser;
+				lock (u.userLock) {
+					localUser = new GloebitUser(u);
+				}
+	
+				return localUser;
+			}
+			catch(Exception e)
+			{
+				m_log.DebugFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
+			}
         }
 
         public static void InvalidateCache(UUID agentID) {

--- a/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
+++ b/addon-modules/Gloebit/GloebitMoneyModule/GloebitUser.cs
@@ -113,7 +113,7 @@ namespace Gloebit.GloebitMoneyModule {
                     users = GloebitUserData.Instance.Get(keys, values);
                 } catch(Exception e) {
                     m_log.WarnFormat("[GLOEBITMONEYMODULE] failed GloebitUser.Get because {0}", e);
-                    users = [];
+                    users = new GloebitUser[0];
                 }
 
                 switch(users.Length) {


### PR DESCRIPTION
As I mentioned in the issue ticket no module should alone be able to cause process termination of OpenSim, so I added a try catch for the database connection in hope to remove the unhandled exception that occurs when connection to the database is lost.

This now includes:
- Try catch for database handling aimed to prevent process termination
- Additional debug information on which workflows are used and what OpenSim version is detected
- New http workflow thanks to watcher64 and Ubit
- Spelling mistakes corrected, especially in returns
- Additional config for removing the welcome message
- Hidden config to force workflows in case version number cannot be used
- Removed last compiler warning, module now compiles cleanly

Reading the code I can see a few things that will need to be adjusted at some point as they don't exactly appear all that solid in terms of future-proofing. Given the rapid changes in OpenSim as of late it may not survive a year now. To me some things are done in a roundabout way that seems to just introduce potential parsing issues and other points of communication failures, but maybe I am just seeing things. It would be nice to go over the code again to see if handling of some parts could be streamlined and reduced in complexity.